### PR TITLE
Feature/dx 155 checkout/3 ds2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site/
 .jekyll-cache/
 .jekyll-metadata
 .env
+.vs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,10 +25,12 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
     execjs (2.7.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
+    ffi (1.11.1-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (200)
@@ -209,6 +211,8 @@ GEM
     multipart-post (2.1.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
+    nokogiri (1.10.4-x64-mingw32)
+      mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.2)
@@ -243,6 +247,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   dotenv

--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,8 @@ topbar:
     title: Checkout
   - url: /payments/
     title: Payments
+  - url: /resources/
+    title: Resources
 defaults:
   - values:
       layout: default

--- a/checkout/3DS2-documentation.md
+++ b/checkout/3DS2-documentation.md
@@ -1,0 +1,3876 @@
+---
+title: Swedbank Pay Checkout – 3DS2 Documentation
+sidebar:
+  navigation:
+  - title: Checkout
+    items:
+    - url: /checkout/
+      title: Introduction
+    - url: /checkout/payment
+      title: Payment
+    - url: /checkout/after-payment
+      title: After Payment
+    - url: /checkout/3DS2-documentation
+      title: 3DS2 Documentation
+---
+
+{% include alert.html type="warning"
+                      icon="warning"
+                      header="Site under development"
+                      body="The Developer Portal is under construction and should not be used to integrate against Swedbank Pay's APIs yet." %}
+
+## General
+
+### Glossary
+
+{:.table .table-striped}
+| Term      | Description |
+|:---       |:---        |
+| Recurring (requires recurrenceToken) | Subscription type payment. E.g Monthly debited amount for service.
+| Stored Card | Card data is saved on the consumers profile to allow future payments to be simplified.
+| Verification Transaction (operation Verify) | Create a payment without debiting the consumer. Used to create a recurrenceToken for recurring payments without debiting an amount.
+
+**API Changes for 3DS2.0 in PaymentOrder**
+
+{:.table .table-striped}
+| Change      | Description |
+|:---       |:---        |
+| Removed   | generatePaymentToken removed as stored card is handled by PayEx.
+| Added     | generateRecurrenceToken added to create a token for recurring payments.
+| Added     | Payer object and parameters added to allow decreased chance of authentication challenge flow.
+| Removed   | Some CreditCard object-parameters removed as they will not be eligible in 3DS2.0. (E.g. no3DSecure: true).
+
+## Use Cases: Create Payment Order
+There are three different Create Payment Order cases based on which kind of integration you're set to use.
+
+{:.table .table-striped}
+| Integration      | Definition |
+|:---              |:---        |
+| PayEx Checkout   | The standard setup. The consumer provide details on PayEx end to create a new consumer profile or use an already existing profile of the consumer.
+| PayEx Checkout without Checkin | Anonymous payment. No consumer profile will be created or used in the payment. Does not allow stored cards.
+| PayEx Checkout - Merchant onboarding | The advanced setup. The merchant provides consumer details and PayEx will create a new consumer profile or use an already existing profile of the consumer. An advanced setup needs a separate GDPR agreement and approval from PayEx.
+
+### 1.0 Use Case: PayEx Checkout
+
+{:.code-header}
+**Request**
+
+```http
+POST /psp/paymentorders HTTP/1.1
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+    "paymentorder": {
+        "operation": "Purchase",
+        "currency": "SEK",
+        "amount": 1500,
+        "vatAmount": 0,
+        "description": "Test Purchase",
+        "userAgent": "Mozilla/5.0...",                               
+        "language": "sv-SE",
+        "generateRecurrenceToken": false,                         
+        "disablePaymentMenu": false,                              
+        "urls": {
+            "hostUrls": [ "http://test-dummy.net", "http://test-dummy2.net" ],
+            "completeUrl": "http://test-dummy.net/payment-completed",
+            "cancelUrl": "http://test-dummy.net/payment-canceled",
+            "paymentUrl": "http://test-dummy.net/payment",
+            "callbackUrl": "http://test-dummy.net/payment-callback",     
+            "termsOfServiceUrl": "http://test-dummy.net/termsandconditoons.pdf",
+            "logoUrl": "http://test-dummy.net/logo.png"
+        },
+        "payeeInfo": {
+            "payeeId": "12345678-1234-1234-1234-123456789012",
+            "payeeReference": "CD1234",
+            "payeeName": "Merchant1",                                   
+            "productCategory": "A123",                                   
+            "subsite": "MySubsite",                                      
+            "orderReference" : "or-123456"                                
+        },
+        "payer": {
+            "consumerProfileRef": "string",
+            "email": "string",
+            "msisdn": "string",
+            "workPhoneNumber" : "string",                              
+            "homePhoneNumber" : "string"                                 
+        },
+        "riskIndicator" : {
+            "deliveryEmailAddress" : "string",              
+            "deliveryTimeFrameindicator" : "01",   
+            "preOrderDate" : "YYYYMMDD",                    
+            "preOrderPurchaseIndicator" : "01",          
+            "shipIndicator" : "01",        
+            "giftCardPurchase" : "false",               
+            "reOrderPurchaseIndicator" : "01",           
+            "pickUpAddress" : {                            
+                "name" : "companyname",                    
+                "streetAddress" : "string",                 
+                "coAddress" : "string",                   
+                "city" : "string",
+                "zipCode" : "string",
+                "countryCode" : "string"
+            }
+        },
+        "metadata": {                                                 
+            "key1": "value1",
+            "key2": 2,
+            "key3": 3.1,
+            "key4": false
+        },
+        "items": [                                                
+        {
+        "creditCard": {
+            "rejectCreditCards": false,                           
+            "rejectDebitCards": false,                           
+            "rejectConsumerCards": false,                        
+            "rejectCorporateCards": false                      
+            }
+        }
+        {
+        "invoice": {
+            "feeAmount" : 1900
+          }
+        },
+        {
+        "campaignInvoice": {
+            "campaignCode" : "Campaign1",
+            "feeAmount" : 2900 
+          }
+        },
+        {
+        "swish": {
+            "EnableEcomOnly": false           
+      }
+    }
+   ]
+  }
+}
+```
+
+{:.table .table-striped}
+| Property                                  | Type       | Required | Description   |
+|-------------------------------------------|------------|----------|---------------|
+| paymentorder                              | object     | Y        | The payment order object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| operation                                 | string     | Y        | The operation that the payment order is supposed to perform.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| currency                                  | string     | Y        | The currency of the payment.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| amount                                    | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                      |
+| vatAmount                                 | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                             |
+| description                               | string     | Y        | The description of the payment order.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| userAgent                                 | string     | N        | The user agent of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| language                                  | string     | Y        | The language of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| generateRecurrenceToken                   | boolean    | N        | Determines if a recurrence token should be generated. A recurrence token is primarily used to enable recurring payments through server-to-server calls. Default value is false                                                                                                                                                                                                                                                                                                                                     |
+| urls.hostUrls                             | array      | Y        | The array of URIs valid for embedding of PayEx Hosted Views.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.completeUrl                          | string     | Y        | The URI to redirect the payer to once the payment is completed.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.cancelUrl                            | string     | N        | The URI to redirect the payer to if the payment is canceled.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.paymentUrl                           | string     | N        | The URI that PayEx will redirect back to when the payment menu needs to be loaded, to inspect and act on the current status of the payment. Only used in hosted view. See URLs for details.                                                                                                                                                                                                                                                                                                                        |
+| payeeInfo.payeeName                       | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| payeeInfo.productCategory                 | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process.                                                                                                                                                                                                                                                                                                                            |
+| payeeInfo.subsite                         | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                                                                                                                                                                                                                                                                                                                                               |
+| payeeInfo.orderReference                  | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| payer.consumerProfileRef                  | string     | N        | The consumer profile reference as obtained through the Consumers API.                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| payer.email                               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.msisdn                              | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.homePhoneNumber                     | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.workPhoneNumber                     | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| riskIndicator.deliveryEmailAddress        | string     | N        | For electronic delivery, the email address to which the merchandise was delivered.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| riskIndicator.deliveryTimeFrameIndicator  | string     | N        | Indicates the merchandise delivery timeframe.01 (Electronic Delivery)02 (Same day shipping)03 (Overnight shipping)04 (Two-day or more shipping)                                                                                                                                                                                                                                                                                                                                                                    |
+| riskIndicator.preOrderDate                | string     | N        | For a pre-ordered purchase. The expected date that the merchandise will be available.FORMAT: "YYYYMMDD"                                                                                                                                                                                                                                                                                                                                                                                                            |
+| riskIndicator.preOrderPurchaseIndicator   | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.shipIndicator               | string     | N        | Indicates shipping method chosen for the transaction.01 (Ship to cardholder's billing address)02 (Ship to another verified address on file with merchant)03 (Ship to address that is different than cardholder's billing address)04 (Ship to Store / Pick-up at local store. Store address shall be populated in shipping address fields)05 (Digital goods, includes online services, electronic giftcards and redemption codes)06 (Travel and Event tickets, not shipped)07 (Other, e.g. gaming, digital service) |
+| riskIndicator.giftCardPurchase            | boolean    | N        | true if this is a purchase of a gift card.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| riskIndicator.reOrderPurchaseIndicator    | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.pickUpAddress               | object     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.name          | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.streetAddress | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.coAddress     | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.city          | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.zipCode       | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.countryCode   | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| metadata                                  | object     | N        | The keys and values that should be associated with the payment order. Can be additional identifiers and data you want to associate with the payment.                                                                                                                                                                                                                                                                                                                                                               |
+| items                                     | array      | N        | The array of items that will affect how the payment is performed.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| items.creditCard.rejectDebitCards         | boolean    | N        | true if debit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                             |
+| items.creditCard.rejectCreditCards        | boolean    | N        | true if credit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                            |
+| items.creditCard.rejectConsumerCards      | boolean    | N        | true if consumer cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                          |
+| items.creditCard.rejectCorporateCards     | boolean    | N        | true if corporate cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                         |
+| items.invoice.feeAmount                   | integer    | N        | The fee amount in the lowest monetary unit to apply if the consumer chooses to pay with invoice.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| items.swish.enableEcomOnly                | boolean    | N        | true to only enable Swish on ecommerce transactions.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+
+### 1.1 Use Case: PayEx Checkout without Checkin
+
+
+{:.code-header}
+**Request**
+
+```http
+POST /psp/paymentorders HTTP/1.1
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Purchase",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",                                 
+    "language": "sv-SE",
+    "generateRecurrenceToken": false,                         
+    "disablePaymentMenu": false,                              
+    "urls": {
+      "hostUrls": [ "http://test-dummy.net", "http://test-dummy2.net" ],
+      "completeUrl": "http://test-dummy.net/payment-completed",
+      "cancelUrl": "http://test-dummy.net/payment-canceled",
+      "paymentUrl": "http://test-dymmy.net/payment",
+      "callbackUrl": "http://test-dummy.net/payment-callback",     
+      "termsOfServiceUrl": "http://test-dummy.net/termsandconditoons.pdf",
+      "logoUrl": "http://test-dummy.net/logo.png"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant1",                                    
+      "productCategory": "A123",                                   
+      "subsite": "MySubsite",                                       
+      "orderReference" : "or-123456"                               
+    },
+    "payer": {
+      "nationalIdentifier": {                                      
+        "socialSecurityNumber": "19XXXXXXXXXX",
+        "countryCode": "SE"
+      },
+      "firstName": "string",                      
+      "lastName": "string",                 
+      "email": "string",      
+      "msisdn": "string",                 
+      "workPhoneNumber" : "string",                        
+      "homePhoneNumber" : "string",                        
+      "shippingAddress" : {                    
+        "firstName" : "firstname/compnayname", 
+        "lastName" : "lastname",               
+        "email": "string",       
+        "msisdn": "string",      
+        "streetAddress" : "string",      
+        "coAddress" : "string",          
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "billingAddress" : {                      
+        "firstName" : "firstname/compnayname",  
+        "lastName" : "lastname",                
+        "email": "string",      
+        "msisdn": "string",                
+        "streetAddress" : "string",        
+        "coAddress" : "string",            
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "accountInfo" : {                                 
+        "accountAgeIndicator" : "01",       
+        "accountChangeIndicator" : "01",       
+        "accountPwdChangeIndicator" : "01", 
+        "shippingAddressUsageIndicator" : "01",
+        "shippingNameIndicator" : "01",              
+        "suspiciousAccountActivity" : "01",        
+        "addressMatchIndicator": "false"           
+      }
+     },
+    "riskIndicator" : {
+       "deliveryEmailAddress" : "string",               
+       "deliveryTimeFrameindicator" : "01",    
+       "preOrderDate" : "YYYYMMDD",                     
+       "preOrderPurchaseIndicator" : "01",           
+       "shipIndicator" : "01",        
+       "giftCardPurchase" : "false",               
+       "reOrderPurchaseIndicator" : "01",            
+       "pickUpAddress" : {                              
+           "name" : "companyname",                      
+           "streetAddress" : "string",                  
+           "coAddress" : "string",                      
+           "city" : "string",
+           "zipCode" : "string",
+           "countryCode" : "string"
+       }
+    },
+    "metadata": {                                          
+      "key1": "value1",
+      "key2": 2,
+      "key3": 3.1,
+      "key4": false
+    },
+    "items": [                                             
+    {
+      "creditCard": {
+        "rejectCreditCards": false,                   
+        "rejectDebitCards": false,                    
+        "rejectConsumerCards": false,                 
+        "rejectCorporateCards": false                 
+      }
+    },
+    {
+      "invoice": {
+        "feeAmount" : 1900
+      }
+    },
+    {
+      "campaignInvoice": {
+        "campaignCode" : "Campaign1",
+        "feeAmount" : 2900 
+      }
+    },
+    {
+      "swish": {
+        "EnableEcomOnly": false                 
+      }
+    }
+   ]
+  }
+}
+```
+
+{:.table .table-striped}
+| Property                                      | Type       | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+|-----------------------------------------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder                                  | object     | Y        | The payment order object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| operation                                     | string     | Y        | The operation that the payment order is supposed to perform.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| currency                                      | string     | Y        | The currency of the payment.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| amount                                        | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                      |
+| vatAmount                                     | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                             |
+| description                                   | string     | Y        | The description of the payment order.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| userAgent                                     | string     | N        | The user agent of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| language                                      | string     | Y        | The language of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| generateRecurrenceToken                       | boolean    | N        | Determines if a recurrence token should be generated. A recurrence token is primarily used to enable recurring payments through server-to-server calls. Default value is false                                                                                                                                                                                                                                                                                                                                     |
+| urls.hostUrls                                 | array      | Y        | The array of URIs valid for embedding of PayEx Hosted Views.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.completeUrl                              | string     | Y        | The URI to redirect the payer to once the payment is completed.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.cancelUrl                                | string     | N        | The URI to redirect the payer to if the payment is canceled.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.paymentUrl                               | string     | N        | The URI that PayEx will redirect back to when the payment menu needs to be loaded, to inspect and act on the current status of the payment. Only used in hosted views. Can not be used simultaneously with cancelUrl; only cancelUrl or paymentUrl can be used, not both.                                                                                                                                                                                                                                          |
+| urls.callbackUrl                              | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| urls.termsOfServiceUrl                        | string     | Y        | The URI to the terms of service document the payer must accept in order to complete the payment. Require https.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.logoUrl                                  | string     | Y        | The URI to the logo that will be displayed on redirect pages. Require https.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| payeeInfo.payeeId                             | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| payeeInfo.payeeReference                      | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                                                                                                                                                                                                                                                                                                                                              |
+| payeeInfo.payeeName                           | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| payeeInfo.productCategory                     | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process.                                                                                                                                                                                                                                                                                                                            |
+| payeeInfo.subsite                             | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                                                                                                                                                                                                                                                                                                                                               |
+| payeeInfo.orderReference                      | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| payer.nationalIdentifier                      | object     | N        | Optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.socialSecurityNumber | string     | N        | Optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.countryCode          | string     | N        | Optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.firstName                               | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.lastName                                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.email                                   | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.msisdn                                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.homePhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.workPhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.firstName               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.lastName                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.streetAddress           | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.coAddress               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.city                    | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.zipCode                 | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.countryCode             | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.firstName                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.lastName                 | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.streetAddress            | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.coAddress                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.city                     | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.zipCode                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.countryCode              | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| accountInfo                                   | object     | N        | Optional. If payer is known by merchant and have some kind of registered user then these fields can be set.                                                                                                                                                                                                                                                                                                                                                                                                        |
+| accountInfo.accountAgeIndicator               | string     | N        | Indicates the length of time that the payments account was enrolled in the cardholder's account with merchant.01 (No account, guest)02 (Created during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                     |
+| accountInfo.accountChangeIndicator            | string     | N        | Length of time since the cardholder's account information with the merchant was changed. Including billing etc.01 (Changed during transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                          |
+| accountInfo.accountPwdChangeIndicator         | string     | N        | Indicates the length of time since the cardholder's account with the merchant had a password change or account reset.01 (No change)02 (Changed during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                      |
+| accountInfo.shippingAddressUsageIndicator     | string     | N        | Indicates when the shipping address used for this transaction was first used with the merchant.01 (This transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                                                    |
+| accountInfo.shippingNameIndicator             | string     | N        | Indicates if the Cardholder Name on the account is identical to the shipping Name used for this transaction.01 (Account name identical to shipping name)02 (Account name different than shipping name)                                                                                                                                                                                                                                                                                                             |
+| accountInfo.suspiciousAccountActivity         | string     | N        | Indicates whether merchant has experienced suspicious activity (including previous fraud) on the cardholder account.01 (No suspicious activity has been observed)02 (Suspicious activity has been observed)                                                                                                                                                                                                                                                                                                        |
+| accountInfo.addressMatchIndicator             | boolean    | N        | Allows the 3DS Requestor to indicate to the ACS whether the cardholder’s billing and shipping address are the same.                                                                                                                                                                                                                                                                                                                                                                                                |
+| riskIndicator.deliveryEmailAddress            | string     | N        | For electronic delivery, the email address to which the merchandise was delivered.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| riskIndicator.deliveryTimeFrameIndicator      | string     | N        | Indicates the merchandise delivery timeframe.01 (Electronic Delivery)02 (Same day shipping)03 (Overnight shipping)04 (Two-day or more shipping)                                                                                                                                                                                                                                                                                                                                                                    |
+| riskIndicator.preOrderDate                    | string     | N        | For a pre-ordered purchase. The expected date that the merchandise will be available.FORMAT: "YYYYMMDD"                                                                                                                                                                                                                                                                                                                                                                                                            |
+| riskIndicator.preOrderPurchaseIndicator       | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.shipIndicator                   | string     | N        | Indicates shipping method chosen for the transaction.01 (Ship to cardholder's billing address)02 (Ship to another verified address on file with merchant)03 (Ship to address that is different than cardholder's billing address)04 (Ship to Store / Pick-up at local store. Store address shall be populated in shipping address fields)05 (Digital goods, includes online services, electronic giftcards and redemption codes)06 (Travel and Event tickets, not shipped)07 (Other, e.g. gaming, digital service) |
+| riskIndicator.giftCardPurchase                | boolean    | N        | true if this is a purchase of a gift card.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| riskIndicator.reOrderPurchaseIndicator        | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.pickUpAddress                   | object     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.name              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.streetAddress     | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.coAddress         | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.city              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.zipCode           | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.countryCode       | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| metadata                                      | object     | N        | The keys and values that should be associated with the payment order. Can be additional identifiers and data you want to associate with the payment.                                                                                                                                                                                                                                                                                                                                                               |
+| items                                         | array      | N        | The array of items that will affect how the payment is performed.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| items.creditCard.rejectDebitCards             | boolean    | N        | true if debit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                             |
+| items.creditCard.rejectCreditCards            | boolean    | N        | true if credit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                            |
+| items.creditCard.rejectConsumerCards          | boolean    | N        | true if consumer cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                          |
+| items.creditCard.rejectCorporateCards         | boolean    | N        | true if corporate cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                         |
+| items.invoice.feeAmount                       | integer    | N        | The fee amount in the lowest monetary unit to apply if the consumer chooses to pay with invoice.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| items.swish.enableEcomOnly                    | boolean    | N        | true to only enable Swish on ecommerce transactions.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+
+### 1.2 Use Case: PayEx Checkout - Merchant Onboarding
+
+{:.code-header}
+**Request**
+
+```http
+POST /psp/paymentorders HTTP/1.1
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Purchase",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",                                 
+    "language": "sv-SE",
+    "generateRecurrenceToken": false,                         
+    "disablePaymentMenu": false,                              
+    "urls": {
+      "hostUrls": [ "http://test-dummy.net", "http://test-dummy2.net" ],
+      "completeUrl": "http://test-dummy.net/payment-completed",
+      "cancelUrl": "http://test-dummy.net/payment-canceled",
+      "paymentUrl": "http://test-dummy.net/payment",
+      "callbackUrl": "http://test-dummy.net/payment-callback",     
+      "termsOfServiceUrl": "http://test-dummy.net/termsandconditoons.pdf",
+      "logoUrl": "http://test-dummy.net/logo.png"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant1",                                    
+      "productCategory": "A123",                                   
+      "subsite": "MySubsite",                                       
+      "orderReference" : "or-123456"                               
+    },
+    "payer": {
+      "nationalIdentifier": {                                      
+        "socialSecurityNumber": "19XXXXXXXXXX",
+        "countryCode": "SE"
+      },
+      "firstName": "string",                      
+      "lastName": "string",                 
+      "email": "string",      
+      "msisdn": "string",                 
+      "workPhoneNumber" : "string",                        
+      "homePhoneNumber" : "string",                        
+      "shippingAddress" : {                    
+        "firstName" : "firstname/companyname", 
+        "lastName" : "lastname",               
+        "email": "string",       
+        "msisdn": "string",      
+        "streetAddress" : "string",      
+        "coAddress" : "string",          
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "billingAddress" : {                      
+        "firstName" : "firstname/companyname",  
+        "lastName" : "lastname",                
+        "email": "string",      
+        "msisdn": "string",                
+        "streetAddress" : "string",        
+        "coAddress" : "string",            
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "accountInfo" : {                                 
+        "accountAgeIndicator" : "01",       
+        "accountChangeIndicator" : "01",       
+        "accountPwdChangeIndicator" : "01", 
+        "shippingAddressUsageIndicator" : "01",
+        "shippingNameIndicator" : "01",              
+        "suspiciousAccountActivity" : "01",        
+        "addressMatchIndicator": "false"           
+      }
+     },
+    "riskIndicator" : {
+       "deliveryEmailAddress" : "string",               
+       "deliveryTimeFrameindicator" : "01",    
+       "preOrderDate" : "YYYYMMDD",                     
+       "preOrderPurchaseIndicator" : "01",           
+       "shipIndicator" : "01",        
+       "giftCardPurchase" : "false",               
+       "reOrderPurchaseIndicator" : "01",            
+       "pickUpAddress" : {                              
+           "name" : "companyname",                      
+           "streetAddress" : "string",                  
+           "coAddress" : "string",                      
+           "city" : "string",
+           "zipCode" : "string",
+           "countryCode" : "string"
+       }
+    },
+    "metadata": {                                          
+      "key1": "value1",
+      "key2": 2,
+      "key3": 3.1,
+      "key4": false
+    },
+    "items": [                                             
+    {
+      "creditCard": {
+        "rejectCreditCards": false,                   
+        "rejectDebitCards": false,                    
+        "rejectConsumerCards": false,                 
+        "rejectCorporateCards": false                 
+      }
+    },
+    {
+      "invoice": {
+        "feeAmount" : 1900
+      }
+    },
+    {
+      "campaignInvoice": {
+        "campaignCode" : "Campaign1",
+        "feeAmount" : 2900 
+      }
+    },
+    {
+      "swish": {
+        "EnableEcomOnly": false                 
+      }
+    }
+   ]
+  }
+}
+```
+
+{:.table .table-striped}
+| Property                                      | Type       | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+|-----------------------------------------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder                                  | object     | Y        | The payment order object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| operation                                     | string     | Y        | The operation that the payment order is supposed to perform.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| currency                                      | string     | Y        | The currency of the payment.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| amount                                        | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                      |
+| vatAmount                                     | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                             |
+| description                                   | string     | Y        | The description of the payment order.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| userAgent                                     | string     | N        | The user agent of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| language                                      | string     | Y        | The language of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| generateRecurrenceToken                       | boolean    | N        | Determines if a recurrence token should be generated. A recurrence token is primarily used to enable recurring payments through server-to-server calls. Default value is false                                                                                                                                                                                                                                                                                                                                     |
+| urls.hostUrls                                 | array      | Y        | The array of URIs valid for embedding of PayEx Hosted Views.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.completeUrl                              | string     | Y        | The URI to redirect the payer to once the payment is completed.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.cancelUrl                                | string     | N        | The URI to redirect the payer to if the payment is canceled.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.paymentUrl                               | string     | N        | The URI that PayEx will redirect back to when the payment menu needs to be loaded, to inspect and act on the current status of the payment. Only used in hosted views. Can not be used simultaneously with cancelUrl; only cancelUrl or paymentUrl can be used, not both.                                                                                                                                                                                                                                          |
+| urls.callbackUrl                              | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| urls.termsOfServiceUrl                        | string     | Y        | The URI to the terms of service document the payer must accept in order to complete the payment. Require https.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.logoUrl                                  | string     | Y        | The URI to the logo that will be displayed on redirect pages. Require https.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| payeeInfo.payeeId                             | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| payeeInfo.payeeReference                      | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                                                                                                                                                                                                                                                                                                                                              |
+| payeeInfo.payeeName                           | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| payeeInfo.productCategory                     | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process.                                                                                                                                                                                                                                                                                                                            |
+| payeeInfo.subsite                             | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                                                                                                                                                                                                                                                                                                                                               |
+| payeeInfo.orderReference                      | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| payer.nationalIdentifier                      | object     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.socialSecurityNumber | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.countryCode          | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.firstName                               | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.lastName                                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.email                                   | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.msisdn                                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.homePhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.workPhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.firstName               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.lastName                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.streetAddress           | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.coAddress               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.city                    | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.zipCode                 | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.countryCode             | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.firstName                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.lastName                 | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.streetAddress            | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.coAddress                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.city                     | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.zipCode                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.countryCode              | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| accountInfo                                   | object     | N        | Optional. If payer is known by merchant and have some kind of registered user then these fields can be set.                                                                                                                                                                                                                                                                                                                                                                                                        |
+| accountInfo.accountAgeIndicator               | string     | N        | Indicates the length of time that the payments account was enrolled in the cardholder's account with merchant.01 (No account, guest)02 (Created during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                     |
+| accountInfo.accountChangeIndicator            | string     | N        | Length of time since the cardholder's account information with the merchant was changed. Including billing etc.01 (Changed during transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                          |
+| accountInfo.accountPwdChangeIndicator         | string     | N        | Indicates the length of time since the cardholder's account with the merchant had a password change or account reset.01 (No change)02 (Changed during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                      |
+| accountInfo.shippingAddressUsageIndicator     | string     | N        | Indicates when the shipping address used for this transaction was first used with the merchant.01 (This transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                                                    |
+| accountInfo.shippingNameIndicator             | string     | N        | Indicates if the Cardholder Name on the account is identical to the shipping Name used for this transaction.01 (Account name identical to shipping name)02 (Account name different than shipping name)                                                                                                                                                                                                                                                                                                             |
+| accountInfo.suspiciousAccountActivity         | string     | N        | Indicates whether merchant has experienced suspicious activity (including previous fraud) on the cardholder account.01 (No suspicious activity has been observed)02 (Suspicious activity has been observed)                                                                                                                                                                                                                                                                                                        |
+| accountInfo.addressMatchIndicator             | boolean    | N        | Allows the 3DS Requestor to indicate to the ACS whether the cardholder’s billing and shipping address are the same.                                                                                                                                                                                                                                                                                                                                                                                                |
+| riskIndicator.deliveryEmailAddress            | string     | N        | For electronic delivery, the email address to which the merchandise was delivered.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| riskIndicator.deliveryTimeFrameIndicator      | string     | N        | Indicates the merchandise delivery timeframe.01 (Electronic Delivery)02 (Same day shipping)03 (Overnight shipping)04 (Two-day or more shipping)                                                                                                                                                                                                                                                                                                                                                                    |
+| riskIndicator.preOrderDate                    | string     | N        | For a pre-ordered purchase. The expected date that the merchandise will be available.FORMAT: "YYYYMMDD"                                                                                                                                                                                                                                                                                                                                                                                                            |
+| riskIndicator.preOrderPurchaseIndicator       | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.shipIndicator                   | string     | N        | Indicates shipping method chosen for the transaction.01 (Ship to cardholder's billing address)02 (Ship to another verified address on file with merchant)03 (Ship to address that is different than cardholder's billing address)04 (Ship to Store / Pick-up at local store. Store address shall be populated in shipping address fields)05 (Digital goods, includes online services, electronic giftcards and redemption codes)06 (Travel and Event tickets, not shipped)07 (Other, e.g. gaming, digital service) |
+| riskIndicator.giftCardPurchase                | boolean    | N        | true if this is a purchase of a gift card.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| riskIndicator.reOrderPurchaseIndicator        | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.pickUpAddress                   | object     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.name              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.streetAddress     | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.coAddress         | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.city              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.zipCode           | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.countryCode       | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| metadata                                      | object     | N        | The keys and values that should be associated with the payment order. Can be additional identifiers and data you want to associate with the payment.                                                                                                                                                                                                                                                                                                                                                               |
+| items                                         | array      | N        | The array of items that will affect how the payment is performed.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| items.creditCard.rejectDebitCards             | boolean    | N        | true if debit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                             |
+| items.creditCard.rejectCreditCards            | boolean    | N        | true if credit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                            |
+| items.creditCard.rejectConsumerCards          | boolean    | N        | true if consumer cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                          |
+| items.creditCard.rejectCorporateCards         | boolean    | N        | true if corporate cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                         |
+| items.invoice.feeAmount                       | integer    | N        | The fee amount in the lowest monetary unit to apply if the consumer chooses to pay with invoice.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| items.swish.enableEcomOnly                    | boolean    | N        | true to only enable Swish on ecommerce transactions.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+
+## Use Cases: Payments
+The following use case scenarios (e.g 1.0 Use Case: Regular Payments) will follow the Create Payment Order  [1.2 Use Case: PayEx Checkout - Merchant onboarding](#12-use-case-payex-checkout---merchant-onboarding)
+
+## 1.0 Use Case: Regular Payments
+A regular payment for single debit transaction.
+
+{:.table .table-striped}
+| Integration                                                | Allowed |
+|------------------------------------------------------------|---------|
+| PayEx Checkout with Checkin                                | Yes     |
+| PayEx Checkout without Checkin                             | Yes     |
+| PayEx Checkout without Checkin. Merchant onboards consumer | Yes     |
+
+{:.table .table-striped}
+| Function         | Allowed |
+|------------------|---------|
+| Recurring        | No      |
+| Store card       | No      |
+| Operation Verify | No      |
+
+**The example requests will have specific parameters set to true or false if it's required in the scenario.**
+
+### 1.1 Create Payment Order
+Example follows Create Payment Order [1.2 Use Case: PayEx Checkout - Merchant onboarding](#12-use-case-payex-checkout---merchant-onboarding)
+
+{:.code-header}
+**Request**
+
+```http
+POST /psp/paymentorders HTTP/1.1
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Purchase",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",                                 
+    "language": "sv-SE",
+    "generateRecurrenceToken": false,                         
+    "disablePaymentMenu": false,                              
+    "urls": {
+      "hostUrls": [ "http://test-dummy.net", "http://test-dummy2.net" ],
+      "completeUrl": "http://test-dummy.net/payment-completed",
+      "cancelUrl": "http://test-dummy.net/payment-canceled",
+      "paymentUrl": "http://test-dummy.net/payment",
+      "callbackUrl": "http://test-dummy.net/payment-callback",     
+      "termsOfServiceUrl": "http://test-dummy.net/termsandconditoons.pdf",
+      "logoUrl": "http://test-dummy.net/logo.png"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant1",                                    
+      "productCategory": "A123",                                   
+      "subsite": "MySubsite",                                       
+      "orderReference" : "or-123456"                               
+    },
+    "payer": {
+      "nationalIdentifier": {                                      
+        "socialSecurityNumber": "19XXXXXXXXXX",
+        "countryCode": "SE"
+      },
+      "firstName": "string",                      
+      "lastName": "string",                 
+      "email": "string",      
+      "msisdn": "string",                 
+      "workPhoneNumber" : "string",                        
+      "homePhoneNumber" : "string",                        
+      "shippingAddress" : {                    
+        "firstName" : "firstname/companyname", 
+        "lastName" : "lastname",               
+        "email": "string",       
+        "msisdn": "string",      
+        "streetAddress" : "string",      
+        "coAddress" : "string",          
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "billingAddress" : {                      
+        "firstName" : "firstname/companyname",  
+        "lastName" : "lastname",                
+        "email": "string",      
+        "msisdn": "string",                
+        "streetAddress" : "string",        
+        "coAddress" : "string",            
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "accountInfo" : {                                 
+        "accountAgeIndicator" : "01",       
+        "accountChangeIndicator" : "01",       
+        "accountPwdChangeIndicator" : "01", 
+        "shippingAddressUsageIndicator" : "01",
+        "shippingNameIndicator" : "01",              
+        "suspiciousAccountActivity" : "01",        
+        "addressMatchIndicator": "false"           
+      }
+     },
+    "riskIndicator" : {
+       "deliveryEmailAddress" : "string",               
+       "deliveryTimeFrameindicator" : "01",    
+       "preOrderDate" : "YYYYMMDD",                     
+       "preOrderPurchaseIndicator" : "01",           
+       "shipIndicator" : "01",        
+       "giftCardPurchase" : "false",               
+       "reOrderPurchaseIndicator" : "01",            
+       "pickUpAddress" : {                              
+           "name" : "companyname",                      
+           "streetAddress" : "string",                  
+           "coAddress" : "string",                      
+           "city" : "string",
+           "zipCode" : "string",
+           "countryCode" : "string"
+       }
+    },
+    "metadata": {                                          
+      "key1": "value1",
+      "key2": 2,
+      "key3": 3.1,
+      "key4": false
+    },
+    "items": [                                             
+    {
+      "creditCard": {
+        "rejectCreditCards": false,                   
+        "rejectDebitCards": false,                    
+        "rejectConsumerCards": false,                 
+        "rejectCorporateCards": false                 
+      }
+    },
+    {
+      "invoice": {
+        "feeAmount" : 1900
+      }
+    },
+    {
+      "campaignInvoice": {
+        "campaignCode" : "Campaign1",
+        "feeAmount" : 2900 
+      }
+    },
+    {
+      "swish": {
+        "EnableEcomOnly": false                 
+      }
+    }
+   ]
+  }
+}
+```
+### 1.2 Create Payment Order Properties
+
+{:.table.table-striped}
+| Property                                      | Type       | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+|-----------------------------------------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder                                  | object     | Y        | The payment order object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| operation                                     | string     | Y        | The operation that the payment order is supposed to perform.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| currency                                      | string     | Y        | The currency of the payment.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| amount                                        | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                      |
+| vatAmount                                     | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                             |
+| description                                   | string     | Y        | The description of the payment order.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| userAgent                                     | string     | N        | The user agent of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| language                                      | string     | Y        | The language of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| generateRecurrenceToken                       | boolean    | N        | Determines if a recurrence token should be generated. A recurrence token is primarily used to enable recurring payments through server-to-server calls. Default value is false                                                                                                                                                                                                                                                                                                                                     |
+| urls.hostUrls                                 | array      | Y        | The array of URIs valid for embedding of PayEx Hosted Views.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.completeUrl                              | string     | Y        | The URI to redirect the payer to once the payment is completed.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.cancelUrl                                | string     | N        | The URI to redirect the payer to if the payment is canceled.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.paymentUrl                               | string     | N        | The URI that PayEx will redirect back to when the payment menu needs to be loaded, to inspect and act on the current status of the payment. Only used in hosted views. Can not be used simultaneously with cancelUrl; only cancelUrl or paymentUrl can be used, not both.                                                                                                                                                                                                                                          |
+| urls.callbackUrl                              | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| urls.termsOfServiceUrl                        | string     | Y        | The URI to the terms of service document the payer must accept in order to complete the payment. Require https.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.logoUrl                                  | string     | Y        | The URI to the logo that will be displayed on redirect pages. Require https.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| payeeInfo.payeeId                             | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| payeeInfo.payeeReference                      | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                                                                                                                                                                                                                                                                                                                                              |
+| payeeInfo.payeeName                           | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| payeeInfo.productCategory                     | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process.                                                                                                                                                                                                                                                                                                                            |
+| payeeInfo.subsite                             | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                                                                                                                                                                                                                                                                                                                                               |
+| payeeInfo.orderReference                      | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| payer.nationalIdentifier                      | object     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.socialSecurityNumber | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.countryCode          | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.firstName                               | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.lastName                                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.email                                   | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.msisdn                                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.homePhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.workPhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.firstName               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.lastName                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.streetAddress           | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.coAddress               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.city                    | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.zipCode                 | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.countryCode             | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.firstName                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.lastName                 | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.streetAddress            | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.coAddress                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.city                     | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.zipCode                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.countryCode              | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| accountInfo                                   | object     | N        | Optional. If payer is known by merchant and have some kind of registered user then these fields can be set.                                                                                                                                                                                                                                                                                                                                                                                                        |
+| accountInfo.accountAgeIndicator               | string     | N        | Indicates the length of time that the payments account was enrolled in the cardholder's account with merchant.01 (No account, guest)02 (Created during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                     |
+| accountInfo.accountChangeIndicator            | string     | N        | Length of time since the cardholder's account information with the merchant was changed. Including billing etc.01 (Changed during transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                          |
+| accountInfo.accountPwdChangeIndicator         | string     | N        | Indicates the length of time since the cardholder's account with the merchant had a password change or account reset.01 (No change)02 (Changed during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                      |
+| accountInfo.shippingAddressUsageIndicator     | string     | N        | Indicates when the shipping address used for this transaction was first used with the merchant.01 (This transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                                                    |
+| accountInfo.shippingNameIndicator             | string     | N        | Indicates if the Cardholder Name on the account is identical to the shipping Name used for this transaction.01 (Account name identical to shipping name)02 (Account name different than shipping name)                                                                                                                                                                                                                                                                                                             |
+| accountInfo.suspiciousAccountActivity         | string     | N        | Indicates whether merchant has experienced suspicious activity (including previous fraud) on the cardholder account.01 (No suspicious activity has been observed)02 (Suspicious activity has been observed)                                                                                                                                                                                                                                                                                                        |
+| accountInfo.addressMatchIndicator             | boolean    | N        | Allows the 3DS Requestor to indicate to the ACS whether the cardholder’s billing and shipping address are the same.                                                                                                                                                                                                                                                                                                                                                                                                |
+| riskIndicator.deliveryEmailAddress            | string     | N        | For electronic delivery, the email address to which the merchandise was delivered.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| riskIndicator.deliveryTimeFrameIndicator      | string     | N        | Indicates the merchandise delivery timeframe.01 (Electronic Delivery)02 (Same day shipping)03 (Overnight shipping)04 (Two-day or more shipping)                                                                                                                                                                                                                                                                                                                                                                    |
+| riskIndicator.preOrderDate                    | string     | N        | For a pre-ordered purchase. The expected date that the merchandise will be available.FORMAT: "YYYYMMDD"                                                                                                                                                                                                                                                                                                                                                                                                            |
+| riskIndicator.preOrderPurchaseIndicator       | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.shipIndicator                   | string     | N        | Indicates shipping method chosen for the transaction.01 (Ship to cardholder's billing address)02 (Ship to another verified address on file with merchant)03 (Ship to address that is different than cardholder's billing address)04 (Ship to Store / Pick-up at local store. Store address shall be populated in shipping address fields)05 (Digital goods, includes online services, electronic giftcards and redemption codes)06 (Travel and Event tickets, not shipped)07 (Other, e.g. gaming, digital service) |
+| riskIndicator.giftCardPurchase                | boolean    | N        | true if this is a purchase of a gift card.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| riskIndicator.reOrderPurchaseIndicator        | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.pickUpAddress                   | object     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.name              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.streetAddress     | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.coAddress         | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.city              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.zipCode           | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.countryCode       | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| metadata                                      | object     | N        | The keys and values that should be associated with the payment order. Can be additional identifiers and data you want to associate with the payment.                                                                                                                                                                                                                                                                                                                                                               |
+| items                                         | array      | N        | The array of items that will affect how the payment is performed.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| items.creditCard.rejectDebitCards             | boolean    | N        | true if debit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                             |
+| items.creditCard.rejectCreditCards            | boolean    | N        | true if credit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                            |
+| items.creditCard.rejectConsumerCards          | boolean    | N        | true if consumer cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                          |
+| items.creditCard.rejectCorporateCards         | boolean    | N        | true if corporate cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                         |
+| items.invoice.feeAmount                       | integer    | N        | The fee amount in the lowest monetary unit to apply if the consumer chooses to pay with invoice.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| items.swish.enableEcomOnly                    | boolean    | N        | true to only enable Swish on ecommerce transactions.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+
+### 1.3 Create Payment Order Response
+
+{:.code-header}
+**Response**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "created": "2016-09-14T13:21:29.3182115Z",
+    "updated": "2016-09-14T13:21:57.6627579Z",
+    "state": "Ready",
+    "operation": "Purchase",
+    "intent": "Authorization",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "remainingCaptureAmount": 1500,
+    "remainingCancellationAmount": 1500,
+    "remainingReversalAmount": 0,
+    "description": "Test Purchase",
+    "initiatingSystemUserAgent": "PostmanRuntime/3.0.1",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+    "payeeInfo" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+    "settings": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" },
+    "payers": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payers" },
+    "payments": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payments" },
+    "items": [
+      {
+        "creditCard": {
+          "cardBrands": [ "Visa", "MasterCard", "Ica", "etc..." ]
+        }
+      },
+      { "invoice": {} },
+      { "campaignInvoice": {} },
+      { "swish": {} },
+      { "vipps": {} }
+    ]
+  },
+  "operations": [
+    {
+      "href": "https://ecom.payex.com/paymentorders/123456123412341234123456789012",
+      "rel": "redirect-paymentorder",
+      "method": "GET",
+      "contentType": "application/json"
+    },
+    {
+      "href": "https://ecom.dev.payex.com/paymentmenu/scripts/client/client-paymentmenu.js",
+      "rel": "view-paymentorder",
+      "method": "GET",
+      "contentType": "application/javascript"
+    }
+  ]
+}
+```
+
+## 2.0 Use Case: Recurring Payments
+Create a recurrenceToken with an initial purchase or verify paymentOrder to enable the recurring scenario. 
+
+{:.table.table-striped}
+| Integration                                                | Allowed |
+|------------------------------------------------------------|---------|
+| PayEx Checkout with Checkin                                | Yes     |
+| PayEx Checkout without Checkin                             | Yes     |
+| PayEx Checkout without Checkin. Merchant onboards consumer | Yes     |
+
+{:.table.table-striped}
+| Function         | Allowed |
+|------------------|---------|
+| Recurring        | Yes     |
+| Store card       | No      |
+| Operation Verify | Yes     |
+
+**The example requests will have specific parameters set to true or false if it's required in the scenario.**
+
+### 2.1 Create Payment Order with initiating purchase
+
+Set generateRecurrenceToken value to **true** and a recurrenceToken will be available to retrieve after the completed payment.
+
+Example follows Create Payment Order [1.2 Use Case: PayEx Checkout - Merchant onboarding](#12-use-case-payex-checkout---merchant-onboarding)
+
+{:.code-header}
+**Request**
+```http
+POST /psp/paymentorders HTTP/1.1
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Purchase",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",                                 
+    "language": "sv-SE",
+    "generateRecurrenceToken": true,                         
+    "disablePaymentMenu": false,                              
+    "urls": {
+      "hostUrls": [ "http://test-dummy.net", "http://test-dummy2.net" ],
+      "completeUrl": "http://test-dummy.net/payment-completed",
+      "cancelUrl": "http://test-dummy.net/payment-canceled",
+      "paymentUrl": "http://test-dummy.net/payment",
+      "callbackUrl": "http://test-dummy.net/payment-callback",     
+      "termsOfServiceUrl": "http://test-dummy.net/termsandconditoons.pdf",
+      "logoUrl": "http://test-dummy.net/logo.png"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant1",                                    
+      "productCategory": "A123",                                   
+      "subsite": "MySubsite",                                       
+      "orderReference" : "or-123456"                               
+    },
+    "payer": {
+      "nationalIdentifier": {                                      
+        "socialSecurityNumber": "19XXXXXXXXXX",
+        "countryCode": "SE"
+      },
+      "firstName": "string",                      
+      "lastName": "string",                 
+      "email": "string",      
+      "msisdn": "string",                 
+      "workPhoneNumber" : "string",                        
+      "homePhoneNumber" : "string",                        
+      "shippingAddress" : {                    
+        "firstName" : "firstname/companyname", 
+        "lastName" : "lastname",               
+        "email": "string",       
+        "msisdn": "string",      
+        "streetAddress" : "string",      
+        "coAddress" : "string",          
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "billingAddress" : {                      
+        "firstName" : "firstname/companyname",  
+        "lastName" : "lastname",                
+        "email": "string",      
+        "msisdn": "string",                
+        "streetAddress" : "string",        
+        "coAddress" : "string",            
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "accountInfo" : {                                 
+        "accountAgeIndicator" : "01",       
+        "accountChangeIndicator" : "01",       
+        "accountPwdChangeIndicator" : "01", 
+        "shippingAddressUsageIndicator" : "01",
+        "shippingNameIndicator" : "01",              
+        "suspiciousAccountActivity" : "01",        
+        "addressMatchIndicator": "false"           
+      }
+     },
+    "riskIndicator" : {
+       "deliveryEmailAddress" : "string",               
+       "deliveryTimeFrameindicator" : "01",    
+       "preOrderDate" : "YYYYMMDD",                     
+       "preOrderPurchaseIndicator" : "01",           
+       "shipIndicator" : "01",        
+       "giftCardPurchase" : "false",               
+       "reOrderPurchaseIndicator" : "01",            
+       "pickUpAddress" : {                              
+           "name" : "companyname",                      
+           "streetAddress" : "string",                  
+           "coAddress" : "string",                      
+           "city" : "string",
+           "zipCode" : "string",
+           "countryCode" : "string"
+       }
+    },
+    "metadata": {                                          
+      "key1": "value1",
+      "key2": 2,
+      "key3": 3.1,
+      "key4": false
+    },
+    "items": [                                             
+    {
+      "creditCard": {
+        "rejectCreditCards": false,                   
+        "rejectDebitCards": false,                    
+        "rejectConsumerCards": false,                 
+        "rejectCorporateCards": false                 
+      }
+    },
+    {
+      "invoice": {
+        "feeAmount" : 1900
+      }
+    },
+    {
+      "campaignInvoice": {
+        "campaignCode" : "Campaign1",
+        "feeAmount" : 2900 
+      }
+    },
+    {
+      "swish": {
+        "EnableEcomOnly": false                 
+      }
+    }
+   ]
+  }
+}
+```
+
+{:.table.table-striped}
+| Property                                      | Type       | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+|-----------------------------------------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder                                  | object     | Y        | The payment order object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| operation                                     | string     | Y        | The operation that the payment order is supposed to perform.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| currency                                      | string     | Y        | The currency of the payment.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| amount                                        | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                      |
+| vatAmount                                     | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                             |
+| description                                   | string     | Y        | The description of the payment order.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| userAgent                                     | string     | N        | The user agent of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| language                                      | string     | Y        | The language of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| generateRecurrenceToken                       | boolean    | N        | Determines if a recurrence token should be generated. A recurrence token is primarily used to enable recurring payments through server-to-server calls. Default value is false                                                                                                                                                                                                                                                                                                                                     |
+| urls.hostUrls                                 | array      | Y        | The array of URIs valid for embedding of PayEx Hosted Views.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.completeUrl                              | string     | Y        | The URI to redirect the payer to once the payment is completed.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.cancelUrl                                | string     | N        | The URI to redirect the payer to if the payment is canceled.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.paymentUrl                               | string     | N        | The URI that PayEx will redirect back to when the payment menu needs to be loaded, to inspect and act on the current status of the payment. Only used in hosted views. Can not be used simultaneously with cancelUrl; only cancelUrl or paymentUrl can be used, not both.                                                                                                                                                                                                                                          |
+| urls.callbackUrl                              | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| urls.termsOfServiceUrl                        | string     | Y        | The URI to the terms of service document the payer must accept in order to complete the payment. Require https.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.logoUrl                                  | string     | Y        | The URI to the logo that will be displayed on redirect pages. Require https.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| payeeInfo.payeeId                             | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| payeeInfo.payeeReference                      | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                                                                                                                                                                                                                                                                                                                                              |
+| payeeInfo.payeeName                           | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| payeeInfo.productCategory                     | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process.                                                                                                                                                                                                                                                                                                                            |
+| payeeInfo.subsite                             | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                                                                                                                                                                                                                                                                                                                                               |
+| payeeInfo.orderReference                      | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| payer.nationalIdentifier                      | object     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.socialSecurityNumber | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.countryCode          | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.firstName                               | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.lastName                                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.email                                   | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.msisdn                                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.homePhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.workPhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.firstName               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.lastName                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.streetAddress           | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.coAddress               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.city                    | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.zipCode                 | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.countryCode             | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.firstName                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.lastName                 | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.streetAddress            | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.coAddress                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.city                     | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.zipCode                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.countryCode              | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| accountInfo                                   | object     | N        | Optional. If payer is known by merchant and have some kind of registered user then these fields can be set.                                                                                                                                                                                                                                                                                                                                                                                                        |
+| accountInfo.accountAgeIndicator               | string     | N        | Indicates the length of time that the payments account was enrolled in the cardholder's account with merchant.01 (No account, guest)02 (Created during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                     |
+| accountInfo.accountChangeIndicator            | string     | N        | Length of time since the cardholder's account information with the merchant was changed. Including billing etc.01 (Changed during transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                          |
+| accountInfo.accountPwdChangeIndicator         | string     | N        | Indicates the length of time since the cardholder's account with the merchant had a password change or account reset.01 (No change)02 (Changed during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                      |
+| accountInfo.shippingAddressUsageIndicator     | string     | N        | Indicates when the shipping address used for this transaction was first used with the merchant.01 (This transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                                                    |
+| accountInfo.shippingNameIndicator             | string     | N        | Indicates if the Cardholder Name on the account is identical to the shipping Name used for this transaction.01 (Account name identical to shipping name)02 (Account name different than shipping name)                                                                                                                                                                                                                                                                                                             |
+| accountInfo.suspiciousAccountActivity         | string     | N        | Indicates whether merchant has experienced suspicious activity (including previous fraud) on the cardholder account.01 (No suspicious activity has been observed)02 (Suspicious activity has been observed)                                                                                                                                                                                                                                                                                                        |
+| accountInfo.addressMatchIndicator             | boolean    | N        | Allows the 3DS Requestor to indicate to the ACS whether the cardholder’s billing and shipping address are the same.                                                                                                                                                                                                                                                                                                                                                                                                |
+| riskIndicator.deliveryEmailAddress            | string     | N        | For electronic delivery, the email address to which the merchandise was delivered.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| riskIndicator.deliveryTimeFrameIndicator      | string     | N        | Indicates the merchandise delivery timeframe.01 (Electronic Delivery)02 (Same day shipping)03 (Overnight shipping)04 (Two-day or more shipping)                                                                                                                                                                                                                                                                                                                                                                    |
+| riskIndicator.preOrderDate                    | string     | N        | For a pre-ordered purchase. The expected date that the merchandise will be available.FORMAT: "YYYYMMDD"                                                                                                                                                                                                                                                                                                                                                                                                            |
+| riskIndicator.preOrderPurchaseIndicator       | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.shipIndicator                   | string     | N        | Indicates shipping method chosen for the transaction.01 (Ship to cardholder's billing address)02 (Ship to another verified address on file with merchant)03 (Ship to address that is different than cardholder's billing address)04 (Ship to Store / Pick-up at local store. Store address shall be populated in shipping address fields)05 (Digital goods, includes online services, electronic giftcards and redemption codes)06 (Travel and Event tickets, not shipped)07 (Other, e.g. gaming, digital service) |
+| riskIndicator.giftCardPurchase                | boolean    | N        | true if this is a purchase of a gift card.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| riskIndicator.reOrderPurchaseIndicator        | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.pickUpAddress                   | object     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.name              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.streetAddress     | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.coAddress         | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.city              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.zipCode           | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.countryCode       | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| metadata                                      | object     | N        | The keys and values that should be associated with the payment order. Can be additional identifiers and data you want to associate with the payment.                                                                                                                                                                                                                                                                                                                                                               |
+| items                                         | array      | N        | The array of items that will affect how the payment is performed.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| items.creditCard.rejectDebitCards             | boolean    | N        | true if debit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                             |
+| items.creditCard.rejectCreditCards            | boolean    | N        | true if credit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                            |
+| items.creditCard.rejectConsumerCards          | boolean    | N        | true if consumer cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                          |
+| items.creditCard.rejectCorporateCards         | boolean    | N        | true if corporate cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                         |
+| items.invoice.feeAmount                       | integer    | N        | The fee amount in the lowest monetary unit to apply if the consumer chooses to pay with invoice.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| items.swish.enableEcomOnly                    | boolean    | N        | true to only enable Swish on ecommerce transactions.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "created": "2016-09-14T13:21:29.3182115Z",
+    "updated": "2016-09-14T13:21:57.6627579Z",
+    "state": "Ready",
+    "operation": "Purchase",
+    "intent": "Authorization",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "remainingCaptureAmount": 1500,
+    "remainingCancellationAmount": 1500,
+    "remainingReversalAmount": 0,
+    "description": "Test Purchase",
+    "initiatingSystemUserAgent": "PostmanRuntime/3.0.1",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+    "payeeInfo" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+    "settings": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" },
+    "payers": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payers" },
+    "payments": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payments" },
+    "items": [
+      {
+        "creditCard": {
+          "cardBrands": [ "Visa", "MasterCard", "Ica", "etc..." ]
+        }
+      },
+      { "invoice": {} },
+      { "campaignInvoice": {} },
+      { "swish": {} },
+      { "vipps": {} }
+    ]
+  },
+  "operations": [
+    {
+      "href": "https://ecom.payex.com/paymentorders/123456123412341234123456789012",
+      "rel": "redirect-paymentorder",
+      "method": "GET",
+      "contentType": "application/json"
+    },
+    {
+      "href": "https://ecom.dev.payex.com/paymentmenu/scripts/client/client-paymentmenu.js",
+      "rel": "view-paymentorder",
+      "method": "GET",
+      "contentType": "application/javascript"
+    }
+  ]
+}
+```
+
+### 2.2 Retrieve Recurrence Token
+When the consumer has completed their payment in the initially created payment order, you are able to retrieve the recurrenceToken from the payment order.
+
+{:.code-header}
+**Request**
+```http
+GET /psp/paymentorders/<paymentOrderId>/currentpayment HTTP/1.1
+Host: api.payex.com
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+```
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "paymentorder": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "recurrenceToken": "5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "menuElementName": "creditcard",
+    "payment": {
+        "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "number": 1234567890,
+        "instrument": "CreditCard",
+        "created": "2016-09-14T13:21:29.3182115Z",
+        "updated": "2016-09-14T13:21:57.6627579Z",
+        "operation": "Purchase",
+        "intent": "Authorization",
+        "state": "Ready",
+        "currency": "SEK",
+        "amount": 1500,
+        "remainingCaptureAmount": 1500,
+        "remainingCancellationAmount": 1500,
+        "remainingReversalAmount": 0,
+        "description": "Test Purchase",
+        "payerReference": "AB1234",
+        "initiatingSystemUserAgent": "PostmanRuntime/3.0.1",
+        "userAgent": "Mozilla/5.0...",
+        "language": "sv-SE",
+        "paymentToken": "5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "prices": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/prices" },
+        "transactions": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions" },
+        "authorizations": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/authorizations" },
+        "captures": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/captures" },
+        "cancellations": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/cancellations" },
+        "reversals": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/reversals" },
+        "verifications": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/verifications" },
+        "urls" : { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+        "payeeInfo" : { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+        "metadata" : { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/metadata" },
+        "settings": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" }
+    },
+    "operations": []
+}
+```
+
+### 2.3 Recurring Payment
+When you have a recurrence token safely tucked away, you can use this token in a subsequent Recur payment. This will be a server-to-server affair, as we have tied all necessary payment instrument details related to the recurrence token during the initial payment order.
+
+{:.code-header}
+**Request**
+```http
+POST /psp/paymentorders HTTP/1.1
+Host: api.payex.com
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Recur",
+    "intent": "Authorization",
+    "recurrenceToken": "5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Recurrence",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls": {
+      "callbackUrl": "http://test-dummy.net/payment-callback"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant1",
+      "productCategory": "A123",
+      "orderReference": "orderRef123",
+      "subsite": "MySubsite"       
+    }
+  }
+}
+``` 
+
+{:.table.table-striped}
+| Property                  | Type       | Required | Description                                                                                                                                                                             |
+|---------------------------|------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder              | object     | Y        | The payment order object.                                                                                                                                                               |
+| operation                 | string     | Y        | Recur is always used for recurring payments.                                                                                                                                            |
+| intent                    | string     | Y        | The intent of the payment.                                                                                                                                                              |
+| recurrenceToken           | string     | Y        | The reccurenceToken to debit.                                                                                                                                                           |
+| currency                  | string     | Y        | The currency of the payment.                                                                                                                                                            |
+| amount                    | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                           |
+| vatAmount                 | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                  |
+| description               | string     | Y        | The description of the payment order.                                                                                                                                                   |
+| userAgent                 | string     | Y        | The user agent of the payer.                                                                                                                                                            |
+| language                  | string     | Y        | The language of the payer.                                                                                                                                                              |
+| urls.callbackUrl          | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                               |
+| payeeInfo.payeeId         | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                           |
+| payeeInfo.payeeReference  | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                   |
+| payeeInfo.payeeName       | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                |
+| payeeInfo.productCategory | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process. |
+| payeeInfo.orderReference  | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                 |
+| payeeInfo.subsite         | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                    |
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "created": "2016-09-14T13:21:29.3182115Z",
+    "updated": "2016-09-14T13:21:57.6627579Z",
+    "state": "Ready",
+    "operation": "Recur",
+    "intent": "Authorization",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "remainingCaptureAmount": 1500,
+    "remainingCancellationAmount": 1500,
+    "remainingReversalAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+    "payeeInfo" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+    "settings": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" },
+    "payers": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payers" },
+    "payments": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payments" },
+    "items": [
+      {
+        "creditCard": {
+          "cardBrands": [ "Visa", "MasterCard", "Ica", "etc..." ]
+        }
+      },
+      { "invoice": {} },
+      { "campaignInvoice": {} },
+      { "swish": {} },
+      { "vipps": {} }
+    ]
+  },
+  "operations":  [
+      {
+      }
+  ]
+}
+``` 
+
+## 3.0 Use Case: Stored Card Payments
+A payment order where the consumer stores their card during the payment. As you will notice, this scenario is the same as a regular payment. This is because the choice is on the consumers end to store their card data on their profile, this option will be available for the consumer inside the payment menu. If the consumer chooses to store their card data, the used card data will be shown (masked) and available to use in future payments.
+
+If you allow consumers to store cards on their profile without making any purchase, use operation Verify.
+
+{:.table.table-striped}
+| Integration                                                | Allowed |
+|------------------------------------------------------------|---------|
+| PayEx Checkout with Checkin                                | Yes     |
+| PayEx Checkout without Checkin                             | No      |
+| PayEx Checkout without Checkin. Merchant onboards consumer | Yes     |
+
+{:.table.table-striped}
+| Function         | Allowed |
+|------------------|---------|
+| Recurring        | No      |
+| Store card       | Yes     |
+| Operation Verify | Yes     |
+
+**The example requests will have specific parameters set to true or false if it's required in the scenario.**
+
+### 3.1 Create Payment Order
+Example follows Create Payment Order [1.2 Use Case: PayEx Checkout - Merchant onboarding](#12-use-case-payex-checkout---merchant-onboarding)
+
+{:.code-header}
+**Request**
+```http
+POST /psp/paymentorders HTTP/1.1
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Purchase",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",                                 
+    "language": "sv-SE",
+    "generateRecurrenceToken": false,                         
+    "disablePaymentMenu": false,                              
+    "urls": {
+      "hostUrls": [ "http://test-dummy.net", "http://test-dummy2.net" ],
+      "completeUrl": "http://test-dummy.net/payment-completed",
+      "cancelUrl": "http://test-dummy.net/payment-canceled",
+      "paymentUrl": "http://test-dummy.net/payment",
+      "callbackUrl": "http://test-dummy.net/payment-callback",     
+      "termsOfServiceUrl": "http://test-dummy.net/termsandconditoons.pdf",
+      "logoUrl": "http://test-dummy.net/logo.png"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant1",                                    
+      "productCategory": "A123",                                   
+      "subsite": "MySubsite",                                       
+      "orderReference" : "or-123456"                               
+    },
+    "payer": {
+      "nationalIdentifier": {                                      
+        "socialSecurityNumber": "19XXXXXXXXXX",
+        "countryCode": "SE"
+      },
+      "firstName": "string",                      
+      "lastName": "string",                 
+      "email": "string",      
+      "msisdn": "string",                 
+      "workPhoneNumber" : "string",                        
+      "homePhoneNumber" : "string",                        
+      "shippingAddress" : {                    
+        "firstName" : "firstname/companyname", 
+        "lastName" : "lastname",               
+        "email": "string",       
+        "msisdn": "string",      
+        "streetAddress" : "string",      
+        "coAddress" : "string",          
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "billingAddress" : {                      
+        "firstName" : "firstname/companyname",  
+        "lastName" : "lastname",                
+        "email": "string",      
+        "msisdn": "string",                
+        "streetAddress" : "string",        
+        "coAddress" : "string",            
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "accountInfo" : {                                 
+        "accountAgeIndicator" : "01",       
+        "accountChangeIndicator" : "01",       
+        "accountPwdChangeIndicator" : "01", 
+        "shippingAddressUsageIndicator" : "01",
+        "shippingNameIndicator" : "01",              
+        "suspiciousAccountActivity" : "01",        
+        "addressMatchIndicator": "false"           
+      }
+     },
+    "riskIndicator" : {
+       "deliveryEmailAddress" : "string",               
+       "deliveryTimeFrameindicator" : "01",    
+       "preOrderDate" : "YYYYMMDD",                     
+       "preOrderPurchaseIndicator" : "01",           
+       "shipIndicator" : "01",        
+       "giftCardPurchase" : "false",               
+       "reOrderPurchaseIndicator" : "01",            
+       "pickUpAddress" : {                              
+           "name" : "companyname",                      
+           "streetAddress" : "string",                  
+           "coAddress" : "string",                      
+           "city" : "string",
+           "zipCode" : "string",
+           "countryCode" : "string"
+       }
+    },
+    "metadata": {                                          
+      "key1": "value1",
+      "key2": 2,
+      "key3": 3.1,
+      "key4": false
+    },
+    "items": [                                             
+    {
+      "creditCard": {
+        "rejectCreditCards": false,                   
+        "rejectDebitCards": false,                    
+        "rejectConsumerCards": false,                 
+        "rejectCorporateCards": false                 
+      }
+    },
+    {
+      "invoice": {
+        "feeAmount" : 1900
+      }
+    },
+    {
+      "campaignInvoice": {
+        "campaignCode" : "Campaign1",
+        "feeAmount" : 2900 
+      }
+    },
+    {
+      "swish": {
+        "EnableEcomOnly": false                 
+      }
+    }
+   ]
+  }
+}
+```
+
+{:.table.table-striped}
+| Property                                      | Type       | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+|-----------------------------------------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder                                  | object     | Y        | The payment order object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| operation                                     | string     | Y        | The operation that the payment order is supposed to perform.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| currency                                      | string     | Y        | The currency of the payment.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| amount                                        | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                      |
+| vatAmount                                     | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                             |
+| description                                   | string     | Y        | The description of the payment order.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| userAgent                                     | string     | N        | The user agent of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| language                                      | string     | Y        | The language of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| generateRecurrenceToken                       | boolean    | N        | Determines if a recurrence token should be generated. A recurrence token is primarily used to enable recurring payments through server-to-server calls. Default value is false                                                                                                                                                                                                                                                                                                                                     |
+| urls.hostUrls                                 | array      | Y        | The array of URIs valid for embedding of PayEx Hosted Views.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.completeUrl                              | string     | Y        | The URI to redirect the payer to once the payment is completed.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.cancelUrl                                | string     | N        | The URI to redirect the payer to if the payment is canceled.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.paymentUrl                               | string     | N        | The URI that PayEx will redirect back to when the payment menu needs to be loaded, to inspect and act on the current status of the payment. Only used in hosted views. Can not be used simultaneously with cancelUrl; only cancelUrl or paymentUrl can be used, not both.                                                                                                                                                                                                                                          |
+| urls.callbackUrl                              | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| urls.termsOfServiceUrl                        | string     | Y        | The URI to the terms of service document the payer must accept in order to complete the payment. Require https.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.logoUrl                                  | string     | Y        | The URI to the logo that will be displayed on redirect pages. Require https.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| payeeInfo.payeeId                             | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| payeeInfo.payeeReference                      | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                                                                                                                                                                                                                                                                                                                                              |
+| payeeInfo.payeeName                           | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| payeeInfo.productCategory                     | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process.                                                                                                                                                                                                                                                                                                                            |
+| payeeInfo.subsite                             | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                                                                                                                                                                                                                                                                                                                                               |
+| payeeInfo.orderReference                      | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| payer.nationalIdentifier                      | object     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.socialSecurityNumber | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.countryCode          | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.firstName                               | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.lastName                                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.email                                   | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.msisdn                                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.homePhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.workPhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.firstName               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.lastName                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.streetAddress           | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.coAddress               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.city                    | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.zipCode                 | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.countryCode             | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.firstName                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.lastName                 | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.streetAddress            | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.coAddress                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.city                     | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.zipCode                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.countryCode              | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| accountInfo                                   | object     | N        | Optional. If payer is known by merchant and have some kind of registered user then these fields can be set.                                                                                                                                                                                                                                                                                                                                                                                                        |
+| accountInfo.accountAgeIndicator               | string     | N        | Indicates the length of time that the payments account was enrolled in the cardholder's account with merchant.01 (No account, guest)02 (Created during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                     |
+| accountInfo.accountChangeIndicator            | string     | N        | Length of time since the cardholder's account information with the merchant was changed. Including billing etc.01 (Changed during transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                          |
+| accountInfo.accountPwdChangeIndicator         | string     | N        | Indicates the length of time since the cardholder's account with the merchant had a password change or account reset.01 (No change)02 (Changed during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                      |
+| accountInfo.shippingAddressUsageIndicator     | string     | N        | Indicates when the shipping address used for this transaction was first used with the merchant.01 (This transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                                                    |
+| accountInfo.shippingNameIndicator             | string     | N        | Indicates if the Cardholder Name on the account is identical to the shipping Name used for this transaction.01 (Account name identical to shipping name)02 (Account name different than shipping name)                                                                                                                                                                                                                                                                                                             |
+| accountInfo.suspiciousAccountActivity         | string     | N        | Indicates whether merchant has experienced suspicious activity (including previous fraud) on the cardholder account.01 (No suspicious activity has been observed)02 (Suspicious activity has been observed)                                                                                                                                                                                                                                                                                                        |
+| accountInfo.addressMatchIndicator             | boolean    | N        | Allows the 3DS Requestor to indicate to the ACS whether the cardholder’s billing and shipping address are the same.                                                                                                                                                                                                                                                                                                                                                                                                |
+| riskIndicator.deliveryEmailAddress            | string     | N        | For electronic delivery, the email address to which the merchandise was delivered.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| riskIndicator.deliveryTimeFrameIndicator      | string     | N        | Indicates the merchandise delivery timeframe.01 (Electronic Delivery)02 (Same day shipping)03 (Overnight shipping)04 (Two-day or more shipping)                                                                                                                                                                                                                                                                                                                                                                    |
+| riskIndicator.preOrderDate                    | string     | N        | For a pre-ordered purchase. The expected date that the merchandise will be available.FORMAT: "YYYYMMDD"                                                                                                                                                                                                                                                                                                                                                                                                            |
+| riskIndicator.preOrderPurchaseIndicator       | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.shipIndicator                   | string     | N        | Indicates shipping method chosen for the transaction.01 (Ship to cardholder's billing address)02 (Ship to another verified address on file with merchant)03 (Ship to address that is different than cardholder's billing address)04 (Ship to Store / Pick-up at local store. Store address shall be populated in shipping address fields)05 (Digital goods, includes online services, electronic giftcards and redemption codes)06 (Travel and Event tickets, not shipped)07 (Other, e.g. gaming, digital service) |
+| riskIndicator.giftCardPurchase                | boolean    | N        | true if this is a purchase of a gift card.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| riskIndicator.reOrderPurchaseIndicator        | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.pickUpAddress                   | object     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.name              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.streetAddress     | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.coAddress         | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.city              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.zipCode           | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.countryCode       | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| metadata                                      | object     | N        | The keys and values that should be associated with the payment order. Can be additional identifiers and data you want to associate with the payment.                                                                                                                                                                                                                                                                                                                                                               |
+| items                                         | array      | N        | The array of items that will affect how the payment is performed.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| items.creditCard.rejectDebitCards             | boolean    | N        | true if debit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                             |
+| items.creditCard.rejectCreditCards            | boolean    | N        | true if credit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                            |
+| items.creditCard.rejectConsumerCards          | boolean    | N        | true if consumer cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                          |
+| items.creditCard.rejectCorporateCards         | boolean    | N        | true if corporate cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                         |
+| items.invoice.feeAmount                       | integer    | N        | The fee amount in the lowest monetary unit to apply if the consumer chooses to pay with invoice.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| items.swish.enableEcomOnly                    | boolean    | N        | true to only enable Swish on ecommerce transactions.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "created": "2016-09-14T13:21:29.3182115Z",
+    "updated": "2016-09-14T13:21:57.6627579Z",
+    "state": "Ready",
+    "operation": "Purchase",
+    "intent": "Authorization",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "remainingCaptureAmount": 1500,
+    "remainingCancellationAmount": 1500,
+    "remainingReversalAmount": 0,
+    "description": "Test Purchase",
+    "initiatingSystemUserAgent": "PostmanRuntime/3.0.1",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+    "payeeInfo" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+    "settings": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" },
+    "payers": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payers" },
+    "payments": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payments" },
+    "items": [
+      {
+        "creditCard": {
+          "cardBrands": [ "Visa", "MasterCard", "Ica", "etc..." ]
+        }
+      },
+      { "invoice": {} },
+      { "campaignInvoice": {} },
+      { "swish": {} },
+      { "vipps": {} }
+    ]
+  },
+  "operations": [
+    {
+      "href": "https://ecom.payex.com/paymentorders/123456123412341234123456789012",
+      "rel": "redirect-paymentorder",
+      "method": "GET",
+      "contentType": "application/json"
+    },
+    {
+      "href": "https://ecom.dev.payex.com/paymentmenu/scripts/client/client-paymentmenu.js",
+      "rel": "view-paymentorder",
+      "method": "GET",
+      "contentType": "application/javascript"
+    }
+  ]
+}
+```
+
+### 3.2 Stored Card Payment Order
+The card data is stored after the payment is completed and if the consumer chose to store their card. Go back to [3.1 Create Payment Order](#31-create-payment-order) and perform the same request when the consumer wants to make a new purchase but this time it will be in a simplified manner as their card is stored on their checkout profile. 
+
+**Important!** Use Operation Purchase when creating a payment order that should debit the consumer as Verify will not debit any amount.
+
+## 4.0 Use Case: Stored Card and Recurring Combination Payment
+A payment order where you allow the consumer to store their card on their profile and you (the merchant) wants to create a recurrence token for recurring payments.
+
+**Recurring payments**: Set generateRecurrenceToken value to **true** and a recurrenceToken will be available to retrieve after the completed payment.
+
+**Stored Card**: The choice to store a card is on the consumers end, this option will be available for the consumer inside the payment menu. If the consumer chooses to store their card data, the card used will be shown (masked) and available to use in future payments after the completed payment.
+
+{:.table.table-striped}
+| Integration                                                | Allowed |
+|------------------------------------------------------------|---------|
+| PayEx Checkout with Checkin                                | Yes     |
+| PayEx Checkout without Checkin                             | No      |
+| PayEx Checkout without Checkin. Merchant onboards consumer | Yes     |
+
+{:.table.table-striped}
+| Function         | Allowed |
+|------------------|---------|
+| Recurring        | Yes     |
+| Store card       | Yes     |
+| Operation Verify | Yes     |
+
+**The example requests will have specific parameters set to true or false if it's required in the scenario.**
+
+### 4.1 Create Payment Order
+Set generateRecurrenceToken value to **true**
+
+Example follows Create Payment Order [1.2 Use Case: PayEx Checkout - Merchant onboarding](#12-use-case-payex-checkout---merchant-onboarding)
+
+{:.code-header}
+**Request**
+```http 
+POST /psp/paymentorders HTTP/1.1
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Purchase",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",                                 
+    "language": "sv-SE",
+    "generateRecurrenceToken": true,                         
+    "disablePaymentMenu": false,                              
+    "urls": {
+      "hostUrls": [ "http://test-dummy.net", "http://test-dummy2.net" ],
+      "completeUrl": "http://test-dummy.net/payment-completed",
+      "cancelUrl": "http://test-dummy.net/payment-canceled",
+      "paymentUrl": "http://test-dummy.net/payment",
+      "callbackUrl": "http://test-dummy.net/payment-callback",     
+      "termsOfServiceUrl": "http://test-dummy.net/termsandconditoons.pdf",
+      "logoUrl": "http://test-dummy.net/logo.png"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant1",                                    
+      "productCategory": "A123",                                   
+      "subsite": "MySubsite",                                       
+      "orderReference" : "or-123456"                               
+    },
+    "payer": {
+      "nationalIdentifier": {                                      
+        "socialSecurityNumber": "19XXXXXXXXXX",
+        "countryCode": "SE"
+      },
+      "firstName": "string",                      
+      "lastName": "string",                 
+      "email": "string",      
+      "msisdn": "string",                 
+      "workPhoneNumber" : "string",                        
+      "homePhoneNumber" : "string",                        
+      "shippingAddress" : {                    
+        "firstName" : "firstname/companyname", 
+        "lastName" : "lastname",               
+        "email": "string",       
+        "msisdn": "string",      
+        "streetAddress" : "string",      
+        "coAddress" : "string",          
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "billingAddress" : {                      
+        "firstName" : "firstname/companyname",  
+        "lastName" : "lastname",                
+        "email": "string",      
+        "msisdn": "string",                
+        "streetAddress" : "string",        
+        "coAddress" : "string",            
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "accountInfo" : {                                 
+        "accountAgeIndicator" : "01",       
+        "accountChangeIndicator" : "01",       
+        "accountPwdChangeIndicator" : "01", 
+        "shippingAddressUsageIndicator" : "01",
+        "shippingNameIndicator" : "01",              
+        "suspiciousAccountActivity" : "01",        
+        "addressMatchIndicator": "false"           
+      }
+     },
+    "riskIndicator" : {
+       "deliveryEmailAddress" : "string",               
+       "deliveryTimeFrameindicator" : "01",    
+       "preOrderDate" : "YYYYMMDD",                     
+       "preOrderPurchaseIndicator" : "01",           
+       "shipIndicator" : "01",        
+       "giftCardPurchase" : "false",               
+       "reOrderPurchaseIndicator" : "01",            
+       "pickUpAddress" : {                              
+           "name" : "companyname",                      
+           "streetAddress" : "string",                  
+           "coAddress" : "string",                      
+           "city" : "string",
+           "zipCode" : "string",
+           "countryCode" : "string"
+       }
+    },
+    "metadata": {                                          
+      "key1": "value1",
+      "key2": 2,
+      "key3": 3.1,
+      "key4": false
+    },
+    "items": [                                             
+    {
+      "creditCard": {
+        "rejectCreditCards": false,                   
+        "rejectDebitCards": false,                    
+        "rejectConsumerCards": false,                 
+        "rejectCorporateCards": false                 
+      }
+    },
+    {
+      "invoice": {
+        "feeAmount" : 1900
+      }
+    },
+    {
+      "campaignInvoice": {
+        "campaignCode" : "Campaign1",
+        "feeAmount" : 2900 
+      }
+    },
+    {
+      "swish": {
+        "EnableEcomOnly": false                 
+      }
+    }
+   ]
+  }
+}
+```
+
+{:.table.table-striped}
+| Property                                      | Type       | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+|-----------------------------------------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder                                  | object     | Y        | The payment order object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| operation                                     | string     | Y        | The operation that the payment order is supposed to perform.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| currency                                      | string     | Y        | The currency of the payment.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| amount                                        | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                      |
+| vatAmount                                     | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                             |
+| description                                   | string     | Y        | The description of the payment order.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| userAgent                                     | string     | N        | The user agent of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| language                                      | string     | Y        | The language of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| generateRecurrenceToken                       | boolean    | N        | Determines if a recurrence token should be generated. A recurrence token is primarily used to enable recurring payments through server-to-server calls. Default value is false                                                                                                                                                                                                                                                                                                                                     |
+| urls.hostUrls                                 | array      | Y        | The array of URIs valid for embedding of PayEx Hosted Views.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.completeUrl                              | string     | Y        | The URI to redirect the payer to once the payment is completed.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.cancelUrl                                | string     | N        | The URI to redirect the payer to if the payment is canceled.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.paymentUrl                               | string     | N        | The URI that PayEx will redirect back to when the payment menu needs to be loaded, to inspect and act on the current status of the payment. Only used in hosted views. Can not be used simultaneously with cancelUrl; only cancelUrl or paymentUrl can be used, not both.                                                                                                                                                                                                                                          |
+| urls.callbackUrl                              | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| urls.termsOfServiceUrl                        | string     | Y        | The URI to the terms of service document the payer must accept in order to complete the payment. Require https.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.logoUrl                                  | string     | Y        | The URI to the logo that will be displayed on redirect pages. Require https.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| payeeInfo.payeeId                             | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| payeeInfo.payeeReference                      | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                                                                                                                                                                                                                                                                                                                                              |
+| payeeInfo.payeeName                           | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| payeeInfo.productCategory                     | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process.                                                                                                                                                                                                                                                                                                                            |
+| payeeInfo.subsite                             | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                                                                                                                                                                                                                                                                                                                                               |
+| payeeInfo.orderReference                      | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| payer.nationalIdentifier                      | object     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.socialSecurityNumber | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.countryCode          | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.firstName                               | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.lastName                                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.email                                   | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.msisdn                                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.homePhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.workPhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.firstName               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.lastName                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.streetAddress           | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.coAddress               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.city                    | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.zipCode                 | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.countryCode             | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.firstName                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.lastName                 | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.streetAddress            | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.coAddress                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.city                     | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.zipCode                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.countryCode              | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| accountInfo                                   | object     | N        | Optional. If payer is known by merchant and have some kind of registered user then these fields can be set.                                                                                                                                                                                                                                                                                                                                                                                                        |
+| accountInfo.accountAgeIndicator               | string     | N        | Indicates the length of time that the payments account was enrolled in the cardholder's account with merchant.01 (No account, guest)02 (Created during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                     |
+| accountInfo.accountChangeIndicator            | string     | N        | Length of time since the cardholder's account information with the merchant was changed. Including billing etc.01 (Changed during transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                          |
+| accountInfo.accountPwdChangeIndicator         | string     | N        | Indicates the length of time since the cardholder's account with the merchant had a password change or account reset.01 (No change)02 (Changed during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                      |
+| accountInfo.shippingAddressUsageIndicator     | string     | N        | Indicates when the shipping address used for this transaction was first used with the merchant.01 (This transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                                                    |
+| accountInfo.shippingNameIndicator             | string     | N        | Indicates if the Cardholder Name on the account is identical to the shipping Name used for this transaction.01 (Account name identical to shipping name)02 (Account name different than shipping name)                                                                                                                                                                                                                                                                                                             |
+| accountInfo.suspiciousAccountActivity         | string     | N        | Indicates whether merchant has experienced suspicious activity (including previous fraud) on the cardholder account.01 (No suspicious activity has been observed)02 (Suspicious activity has been observed)                                                                                                                                                                                                                                                                                                        |
+| accountInfo.addressMatchIndicator             | boolean    | N        | Allows the 3DS Requestor to indicate to the ACS whether the cardholder’s billing and shipping address are the same.                                                                                                                                                                                                                                                                                                                                                                                                |
+| riskIndicator.deliveryEmailAddress            | string     | N        | For electronic delivery, the email address to which the merchandise was delivered.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| riskIndicator.deliveryTimeFrameIndicator      | string     | N        | Indicates the merchandise delivery timeframe.01 (Electronic Delivery)02 (Same day shipping)03 (Overnight shipping)04 (Two-day or more shipping)                                                                                                                                                                                                                                                                                                                                                                    |
+| riskIndicator.preOrderDate                    | string     | N        | For a pre-ordered purchase. The expected date that the merchandise will be available.FORMAT: "YYYYMMDD"                                                                                                                                                                                                                                                                                                                                                                                                            |
+| riskIndicator.preOrderPurchaseIndicator       | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.shipIndicator                   | string     | N        | Indicates shipping method chosen for the transaction.01 (Ship to cardholder's billing address)02 (Ship to another verified address on file with merchant)03 (Ship to address that is different than cardholder's billing address)04 (Ship to Store / Pick-up at local store. Store address shall be populated in shipping address fields)05 (Digital goods, includes online services, electronic giftcards and redemption codes)06 (Travel and Event tickets, not shipped)07 (Other, e.g. gaming, digital service) |
+| riskIndicator.giftCardPurchase                | boolean    | N        | true if this is a purchase of a gift card.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| riskIndicator.reOrderPurchaseIndicator        | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.pickUpAddress                   | object     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.name              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.streetAddress     | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.coAddress         | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.city              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.zipCode           | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.countryCode       | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| metadata                                      | object     | N        | The keys and values that should be associated with the payment order. Can be additional identifiers and data you want to associate with the payment.                                                                                                                                                                                                                                                                                                                                                               |
+| items                                         | array      | N        | The array of items that will affect how the payment is performed.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| items.creditCard.rejectDebitCards             | boolean    | N        | true if debit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                             |
+| items.creditCard.rejectCreditCards            | boolean    | N        | true if credit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                            |
+| items.creditCard.rejectConsumerCards          | boolean    | N        | true if consumer cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                          |
+| items.creditCard.rejectCorporateCards         | boolean    | N        | true if corporate cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                         |
+| items.invoice.feeAmount                       | integer    | N        | The fee amount in the lowest monetary unit to apply if the consumer chooses to pay with invoice.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| items.swish.enableEcomOnly                    | boolean    | N        | true to only enable Swish on ecommerce transactions.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "created": "2016-09-14T13:21:29.3182115Z",
+    "updated": "2016-09-14T13:21:57.6627579Z",
+    "state": "Ready",
+    "operation": "Purchase",
+    "intent": "Authorization",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "remainingCaptureAmount": 1500,
+    "remainingCancellationAmount": 1500,
+    "remainingReversalAmount": 0,
+    "description": "Test Purchase",
+    "initiatingSystemUserAgent": "PostmanRuntime/3.0.1",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+    "payeeInfo" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+    "settings": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" },
+    "payers": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payers" },
+    "payments": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payments" },
+    "items": [
+      {
+        "creditCard": {
+          "cardBrands": [ "Visa", "MasterCard", "Ica", "etc..." ]
+        }
+      },
+      { "invoice": {} },
+      { "campaignInvoice": {} },
+      { "swish": {} },
+      { "vipps": {} }
+    ]
+  },
+  "operations": [
+    {
+      "href": "https://ecom.payex.com/paymentorders/123456123412341234123456789012",
+      "rel": "redirect-paymentorder",
+      "method": "GET",
+      "contentType": "application/json"
+    },
+    {
+      "href": "https://ecom.dev.payex.com/paymentmenu/scripts/client/client-paymentmenu.js",
+      "rel": "view-paymentorder",
+      "method": "GET",
+      "contentType": "application/javascript"
+    }
+  ]
+}
+```
+
+### 4.2 Recurring Payment
+When the consumer has completed their payment in the initially created payment order, you are able to retrieve the recurrenceToken from the payment order.
+<p>&nbsp;</p>
+
+{:.code-header}
+**Request**
+```http
+GET /psp/paymentorders/<paymentOrderId>/currentpayment HTTP/1.1
+Host: api.payex.com
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+```
+
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "paymentorder": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "recurrenceToken": "5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "menuElementName": "creditcard",
+    "payment": {
+        "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "number": 1234567890,
+        "instrument": "CreditCard",
+        "created": "2016-09-14T13:21:29.3182115Z",
+        "updated": "2016-09-14T13:21:57.6627579Z",
+        "operation": "Purchase",
+        "intent": "Authorization",
+        "state": "Ready",
+        "currency": "SEK",
+        "amount": 1500,
+        "remainingCaptureAmount": 1500,
+        "remainingCancellationAmount": 1500,
+        "remainingReversalAmount": 0,
+        "description": "Test Purchase",
+        "payerReference": "AB1234",
+        "initiatingSystemUserAgent": "PostmanRuntime/3.0.1",
+        "userAgent": "Mozilla/5.0...",
+        "language": "sv-SE",
+        "paymentToken": "5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "prices": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/prices" },
+        "transactions": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions" },
+        "authorizations": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/authorizations" },
+        "captures": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/captures" },
+        "cancellations": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/cancellations" },
+        "reversals": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/reversals" },
+        "verifications": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/verifications" },
+        "urls" : { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+        "payeeInfo" : { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+        "metadata" : { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/metadata" },
+        "settings": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" }
+    },
+    "operations": []
+}
+```
+<p>&nbsp;</p>
+
+**Create a recurring payment**
+
+When you have a recurrence token safely tucked away, you can use this token in a subsequent Recur payment. This will be a server-to-server affair, as we have tied all necessary payment instrument details related to the recurrence token during the initial payment order.
+<p>&nbsp;</p>
+
+
+{:.code-header}
+**Request**
+```http
+POST /psp/paymentorders HTTP/1.1
+Host: api.payex.com
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Recur",
+    "intent": "Authorization",
+    "recurrenceToken": "5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Recurrence",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls": {
+      "callbackUrl": "http://test-dummy.net/payment-callback"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant1",
+      "productCategory": "A123",
+      "orderReference": "orderRef123",
+      "subsite": "MySubsite"       
+    }
+  }
+}
+```
+
+{:.table.table-striped}
+| Property                  | Type       | Required | Description                                                                                                                                                                             |
+|---------------------------|------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder              | object     | Y        | The payment order object.                                                                                                                                                               |
+| operation                 | string     | Y        | Recur is always used for recurring payments.                                                                                                                                            |
+| intent                    | string     | Y        | The intent of the payment.                                                                                                                                                              |
+| recurrenceToken           | string     | Y        | The reccurenceToken to debit.                                                                                                                                                           |
+| currency                  | string     | Y        | The currency of the payment.                                                                                                                                                            |
+| amount                    | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                           |
+| vatAmount                 | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                  |
+| description               | string     | Y        | The description of the payment order.                                                                                                                                                   |
+| userAgent                 | string     | Y        | The user agent of the payer.                                                                                                                                                            |
+| language                  | string     | Y        | The language of the payer.                                                                                                                                                              |
+| urls.callbackUrl          | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                               |
+| payeeInfo.payeeId         | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                           |
+| payeeInfo.payeeReference  | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                   |
+| payeeInfo.payeeName       | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                |
+| payeeInfo.productCategory | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process. |
+| payeeInfo.orderReference  | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                 |
+| payeeInfo.subsite         | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                    |
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "created": "2016-09-14T13:21:29.3182115Z",
+    "updated": "2016-09-14T13:21:57.6627579Z",
+    "state": "Ready",
+    "operation": "Recur",
+    "intent": "Authorization",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "remainingCaptureAmount": 1500,
+    "remainingCancellationAmount": 1500,
+    "remainingReversalAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+    "payeeInfo" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+    "settings": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" },
+    "payers": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payers" },
+    "payments": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payments" },
+    "items": [
+      {
+        "creditCard": {
+          "cardBrands": [ "Visa", "MasterCard", "Ica", "etc..." ]
+        }
+      },
+      { "invoice": {} },
+      { "campaignInvoice": {} },
+      { "swish": {} },
+      { "vipps": {} }
+    ]
+  },
+  "operations":  [
+      {
+      }
+  ]
+}
+```
+
+### 4.3 Stored Card Payment Order
+If the consumer chose to store their card in the previous payment order created in [4.1 Create Payment Order](#41-create-payment-order) you can create a new payment order and the consumers card will be presented in the payment menu.
+
+**Important!** Use Operation Purchase when creating a payment order that should debit the consumer as Verify will not debit any amount.
+Set generateRecurrenceToken value to **false** as you've already created a recurrenceToken for the consumer.
+
+Example follows Create Payment Order [1.2 Use Case: PayEx Checkout - Merchant onboarding](#12-use-case-payex-checkout---merchant-onboarding)
+
+{:.code-header}
+**Request**
+```http
+POST /psp/paymentorders HTTP/1.1
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Purchase",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",                                 
+    "language": "sv-SE",
+    "generateRecurrenceToken": false,                         
+    "disablePaymentMenu": false,                              
+    "urls": {
+      "hostUrls": [ "http://test-dummy.net", "http://test-dummy2.net" ],
+      "completeUrl": "http://test-dummy.net/payment-completed",
+      "cancelUrl": "http://test-dummy.net/payment-canceled",
+      "paymentUrl": "http://test-dummy.net/payment",
+      "callbackUrl": "http://test-dummy.net/payment-callback",     
+      "termsOfServiceUrl": "http://test-dummy.net/termsandconditoons.pdf",
+      "logoUrl": "http://test-dummy.net/logo.png"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant1",                                    
+      "productCategory": "A123",                                   
+      "subsite": "MySubsite",                                       
+      "orderReference" : "or-123456"                               
+    },
+    "payer": {
+      "nationalIdentifier": {                                      
+        "socialSecurityNumber": "19XXXXXXXXXX",
+        "countryCode": "SE"
+      },
+      "firstName": "string",                      
+      "lastName": "string",                 
+      "email": "string",      
+      "msisdn": "string",                 
+      "workPhoneNumber" : "string",                        
+      "homePhoneNumber" : "string",                        
+      "shippingAddress" : {                    
+        "firstName" : "firstname/companyname", 
+        "lastName" : "lastname",               
+        "email": "string",       
+        "msisdn": "string",      
+        "streetAddress" : "string",      
+        "coAddress" : "string",          
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "billingAddress" : {                      
+        "firstName" : "firstname/companyname",  
+        "lastName" : "lastname",                
+        "email": "string",      
+        "msisdn": "string",                
+        "streetAddress" : "string",        
+        "coAddress" : "string",            
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "accountInfo" : {                                 
+        "accountAgeIndicator" : "01",       
+        "accountChangeIndicator" : "01",       
+        "accountPwdChangeIndicator" : "01", 
+        "shippingAddressUsageIndicator" : "01",
+        "shippingNameIndicator" : "01",              
+        "suspiciousAccountActivity" : "01",        
+        "addressMatchIndicator": "false"           
+      }
+     },
+    "riskIndicator" : {
+       "deliveryEmailAddress" : "string",               
+       "deliveryTimeFrameindicator" : "01",    
+       "preOrderDate" : "YYYYMMDD",                     
+       "preOrderPurchaseIndicator" : "01",           
+       "shipIndicator" : "01",        
+       "giftCardPurchase" : "false",               
+       "reOrderPurchaseIndicator" : "01",            
+       "pickUpAddress" : {                              
+           "name" : "companyname",                      
+           "streetAddress" : "string",                  
+           "coAddress" : "string",                      
+           "city" : "string",
+           "zipCode" : "string",
+           "countryCode" : "string"
+       }
+    },
+    "metadata": {                                          
+      "key1": "value1",
+      "key2": 2,
+      "key3": 3.1,
+      "key4": false
+    },
+    "items": [                                             
+    {
+      "creditCard": {
+        "rejectCreditCards": false,                   
+        "rejectDebitCards": false,                    
+        "rejectConsumerCards": false,                 
+        "rejectCorporateCards": false                 
+      }
+    },
+    {
+      "invoice": {
+        "feeAmount" : 1900
+      }
+    },
+    {
+      "campaignInvoice": {
+        "campaignCode" : "Campaign1",
+        "feeAmount" : 2900 
+      }
+    },
+    {
+      "swish": {
+        "EnableEcomOnly": false                 
+      }
+    }
+   ]
+  }
+}
+```
+
+{:.table.table-striped}
+| Property                                      | Type       | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+|-----------------------------------------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder                                  | object     | Y        | The payment order object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| operation                                     | string     | Y        | The operation that the payment order is supposed to perform.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| currency                                      | string     | Y        | The currency of the payment.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| amount                                        | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                      |
+| vatAmount                                     | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                             |
+| description                                   | string     | Y        | The description of the payment order.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| userAgent                                     | string     | N        | The user agent of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| language                                      | string     | Y        | The language of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| generateRecurrenceToken                       | boolean    | N        | Determines if a recurrence token should be generated. A recurrence token is primarily used to enable recurring payments through server-to-server calls. Default value is false                                                                                                                                                                                                                                                                                                                                     |
+| urls.hostUrls                                 | array      | Y        | The array of URIs valid for embedding of PayEx Hosted Views.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.completeUrl                              | string     | Y        | The URI to redirect the payer to once the payment is completed.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.cancelUrl                                | string     | N        | The URI to redirect the payer to if the payment is canceled.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.paymentUrl                               | string     | N        | The URI that PayEx will redirect back to when the payment menu needs to be loaded, to inspect and act on the current status of the payment. Only used in hosted views. Can not be used simultaneously with cancelUrl; only cancelUrl or paymentUrl can be used, not both.                                                                                                                                                                                                                                          |
+| urls.callbackUrl                              | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| urls.termsOfServiceUrl                        | string     | Y        | The URI to the terms of service document the payer must accept in order to complete the payment. Require https.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.logoUrl                                  | string     | Y        | The URI to the logo that will be displayed on redirect pages. Require https.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| payeeInfo.payeeId                             | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| payeeInfo.payeeReference                      | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                                                                                                                                                                                                                                                                                                                                              |
+| payeeInfo.payeeName                           | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| payeeInfo.productCategory                     | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process.                                                                                                                                                                                                                                                                                                                            |
+| payeeInfo.subsite                             | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                                                                                                                                                                                                                                                                                                                                               |
+| payeeInfo.orderReference                      | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| payer.nationalIdentifier                      | object     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.socialSecurityNumber | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.countryCode          | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.firstName                               | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.lastName                                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.email                                   | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.msisdn                                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.homePhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.workPhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.firstName               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.lastName                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.streetAddress           | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.coAddress               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.city                    | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.zipCode                 | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.countryCode             | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.firstName                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.lastName                 | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.streetAddress            | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.coAddress                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.city                     | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.zipCode                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.countryCode              | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| accountInfo                                   | object     | N        | Optional. If payer is known by merchant and have some kind of registered user then these fields can be set.                                                                                                                                                                                                                                                                                                                                                                                                        |
+| accountInfo.accountAgeIndicator               | string     | N        | Indicates the length of time that the payments account was enrolled in the cardholder's account with merchant.01 (No account, guest)02 (Created during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                     |
+| accountInfo.accountChangeIndicator            | string     | N        | Length of time since the cardholder's account information with the merchant was changed. Including billing etc.01 (Changed during transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                          |
+| accountInfo.accountPwdChangeIndicator         | string     | N        | Indicates the length of time since the cardholder's account with the merchant had a password change or account reset.01 (No change)02 (Changed during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                      |
+| accountInfo.shippingAddressUsageIndicator     | string     | N        | Indicates when the shipping address used for this transaction was first used with the merchant.01 (This transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                                                    |
+| accountInfo.shippingNameIndicator             | string     | N        | Indicates if the Cardholder Name on the account is identical to the shipping Name used for this transaction.01 (Account name identical to shipping name)02 (Account name different than shipping name)                                                                                                                                                                                                                                                                                                             |
+| accountInfo.suspiciousAccountActivity         | string     | N        | Indicates whether merchant has experienced suspicious activity (including previous fraud) on the cardholder account.01 (No suspicious activity has been observed)02 (Suspicious activity has been observed)                                                                                                                                                                                                                                                                                                        |
+| accountInfo.addressMatchIndicator             | boolean    | N        | Allows the 3DS Requestor to indicate to the ACS whether the cardholder’s billing and shipping address are the same.                                                                                                                                                                                                                                                                                                                                                                                                |
+| riskIndicator.deliveryEmailAddress            | string     | N        | For electronic delivery, the email address to which the merchandise was delivered.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| riskIndicator.deliveryTimeFrameIndicator      | string     | N        | Indicates the merchandise delivery timeframe.01 (Electronic Delivery)02 (Same day shipping)03 (Overnight shipping)04 (Two-day or more shipping)                                                                                                                                                                                                                                                                                                                                                                    |
+| riskIndicator.preOrderDate                    | string     | N        | For a pre-ordered purchase. The expected date that the merchandise will be available.FORMAT: "YYYYMMDD"                                                                                                                                                                                                                                                                                                                                                                                                            |
+| riskIndicator.preOrderPurchaseIndicator       | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.shipIndicator                   | string     | N        | Indicates shipping method chosen for the transaction.01 (Ship to cardholder's billing address)02 (Ship to another verified address on file with merchant)03 (Ship to address that is different than cardholder's billing address)04 (Ship to Store / Pick-up at local store. Store address shall be populated in shipping address fields)05 (Digital goods, includes online services, electronic giftcards and redemption codes)06 (Travel and Event tickets, not shipped)07 (Other, e.g. gaming, digital service) |
+| riskIndicator.giftCardPurchase                | boolean    | N        | true if this is a purchase of a gift card.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| riskIndicator.reOrderPurchaseIndicator        | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.pickUpAddress                   | object     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.name              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.streetAddress     | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.coAddress         | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.city              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.zipCode           | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.countryCode       | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| metadata                                      | object     | N        | The keys and values that should be associated with the payment order. Can be additional identifiers and data you want to associate with the payment.                                                                                                                                                                                                                                                                                                                                                               |
+| items                                         | array      | N        | The array of items that will affect how the payment is performed.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| items.creditCard.rejectDebitCards             | boolean    | N        | true if debit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                             |
+| items.creditCard.rejectCreditCards            | boolean    | N        | true if credit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                            |
+| items.creditCard.rejectConsumerCards          | boolean    | N        | true if consumer cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                          |
+| items.creditCard.rejectCorporateCards         | boolean    | N        | true if corporate cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                         |
+| items.invoice.feeAmount                       | integer    | N        | The fee amount in the lowest monetary unit to apply if the consumer chooses to pay with invoice.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| items.swish.enableEcomOnly                    | boolean    | N        | true to only enable Swish on ecommerce transactions.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "created": "2016-09-14T13:21:29.3182115Z",
+    "updated": "2016-09-14T13:21:57.6627579Z",
+    "state": "Ready",
+    "operation": "Purchase",
+    "intent": "Authorization",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "remainingCaptureAmount": 1500,
+    "remainingCancellationAmount": 1500,
+    "remainingReversalAmount": 0,
+    "description": "Test Purchase",
+    "initiatingSystemUserAgent": "PostmanRuntime/3.0.1",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+    "payeeInfo" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+    "settings": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" },
+    "payers": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payers" },
+    "payments": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payments" },
+    "items": [
+      {
+        "creditCard": {
+          "cardBrands": [ "Visa", "MasterCard", "Ica", "etc..." ]
+        }
+      },
+      { "invoice": {} },
+      { "campaignInvoice": {} },
+      { "swish": {} },
+      { "vipps": {} }
+    ]
+  },
+  "operations": [
+    {
+      "href": "https://ecom.payex.com/paymentorders/123456123412341234123456789012",
+      "rel": "redirect-paymentorder",
+      "method": "GET",
+      "contentType": "application/json"
+    },
+    {
+      "href": "https://ecom.dev.payex.com/paymentmenu/scripts/client/client-paymentmenu.js",
+      "rel": "view-paymentorder",
+      "method": "GET",
+      "contentType": "application/javascript"
+    }
+  ]
+}
+```
+
+## 5.0 Use Case: Multimerchant Stored Card and Recurring Combination Payment
+
+**<u>THIS SCENARIO IS ONLY FOR MULTIMERCHANT CUSTOMERS</u>**  
+In this scenario we will use 3 active merchants. Merchant One, Merchant Two and Merchant Three.  
+
+A payment order where you allow the consumer to store their card on their profile that will be available for several merchants and you (the merchant) wants to create a recurrence token for recurring payments.  
+  
+**Recurring payments**: Set generateRecurrenceToken value to **true** and a recurrenceToken will be available to retrieve after the completed payment.  
+**The recurrenceToken generated will only be available for the merchant whom generated it.**  
+
+**Stored Card**: The choice to store a card is on the consumers end, this option will be available for the consumer inside the payment menu. If the consumer chooses to store their card data, the card used will be shown (masked) and available to use in future payments after the completed payment. The stored card will be available for the consumer on Merchant One, Merchant Two and Merchant Three.  
+
+{:.table.table-striped}
+| Integration                                                | Allowed |
+|------------------------------------------------------------|---------|
+| PayEx Checkout with Checkin                                | Yes     |
+| PayEx Checkout without Checkin                             | No      |
+| PayEx Checkout without Checkin. Merchant onboards consumer | Yes     |
+
+{:.table.table-striped}
+| Function         | Allowed |
+|------------------|---------|
+| Recurring        | Yes     |
+| Store card       | Yes     |
+| Operation Verify | Yes     |
+
+**The example requests will have specific parameters set to true or false if it's required in the scenario.**  
+
+### 5.1 Create Payment Order - Merchant One  
+
+Set generateRecurrenceToken value to **true**
+
+Example follows Create Payment Order [1.2 Use Case: PayEx Checkout - Merchant onboarding](#12-use-case-payex-checkout---merchant-onboarding)
+
+{:.code-header}
+**Request**
+```http
+POST /psp/paymentorders HTTP/1.1
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Purchase",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",                                 
+    "language": "sv-SE",
+    "generateRecurrenceToken": true,                         
+    "disablePaymentMenu": false,                              
+    "urls": {
+      "hostUrls": [ "http://test-dummy.net", "http://test-dummy2.net" ],
+      "completeUrl": "http://test-dummy.net/payment-completed",
+      "cancelUrl": "http://test-dummy.net/payment-canceled",
+      "paymentUrl": "http://test-dummy.net/payment",
+      "callbackUrl": "http://test-dummy.net/payment-callback",     
+      "termsOfServiceUrl": "http://test-dummy.net/termsandconditoons.pdf",
+      "logoUrl": "http://test-dummy.net/logo.png"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant1",                                    
+      "productCategory": "A123",                                   
+      "subsite": "MySubsite",                                       
+      "orderReference" : "or-123456"                               
+    },
+    "payer": {
+      "nationalIdentifier": {                                      
+        "socialSecurityNumber": "19XXXXXXXXXX",
+        "countryCode": "SE"
+      },
+      "firstName": "string",                      
+      "lastName": "string",                 
+      "email": "string",      
+      "msisdn": "string",                 
+      "workPhoneNumber" : "string",                        
+      "homePhoneNumber" : "string",                        
+      "shippingAddress" : {                    
+        "firstName" : "firstname/companyname", 
+        "lastName" : "lastname",               
+        "email": "string",       
+        "msisdn": "string",      
+        "streetAddress" : "string",      
+        "coAddress" : "string",          
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "billingAddress" : {                      
+        "firstName" : "firstname/companyname",  
+        "lastName" : "lastname",                
+        "email": "string",      
+        "msisdn": "string",                
+        "streetAddress" : "string",        
+        "coAddress" : "string",            
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "accountInfo" : {                                 
+        "accountAgeIndicator" : "01",       
+        "accountChangeIndicator" : "01",       
+        "accountPwdChangeIndicator" : "01", 
+        "shippingAddressUsageIndicator" : "01",
+        "shippingNameIndicator" : "01",              
+        "suspiciousAccountActivity" : "01",        
+        "addressMatchIndicator": "false"           
+      }
+     },
+    "riskIndicator" : {
+       "deliveryEmailAddress" : "string",               
+       "deliveryTimeFrameindicator" : "01",    
+       "preOrderDate" : "YYYYMMDD",                     
+       "preOrderPurchaseIndicator" : "01",           
+       "shipIndicator" : "01",        
+       "giftCardPurchase" : "false",               
+       "reOrderPurchaseIndicator" : "01",            
+       "pickUpAddress" : {                              
+           "name" : "companyname",                      
+           "streetAddress" : "string",                  
+           "coAddress" : "string",                      
+           "city" : "string",
+           "zipCode" : "string",
+           "countryCode" : "string"
+       }
+    },
+    "metadata": {                                          
+      "key1": "value1",
+      "key2": 2,
+      "key3": 3.1,
+      "key4": false
+    },
+    "items": [                                             
+    {
+      "creditCard": {
+        "rejectCreditCards": false,                   
+        "rejectDebitCards": false,                    
+        "rejectConsumerCards": false,                 
+        "rejectCorporateCards": false                 
+      }
+    },
+    {
+      "invoice": {
+        "feeAmount" : 1900
+      }
+    },
+    {
+      "campaignInvoice": {
+        "campaignCode" : "Campaign1",
+        "feeAmount" : 2900 
+      }
+    },
+    {
+      "swish": {
+        "EnableEcomOnly": false                 
+      }
+    }
+   ]
+  }
+}
+```
+
+{:.table.table-striped}
+| Property                                      | Type       | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+|-----------------------------------------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder                                  | object     | Y        | The payment order object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| operation                                     | string     | Y        | The operation that the payment order is supposed to perform.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| currency                                      | string     | Y        | The currency of the payment.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| amount                                        | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                      |
+| vatAmount                                     | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                             |
+| description                                   | string     | Y        | The description of the payment order.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| userAgent                                     | string     | N        | The user agent of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| language                                      | string     | Y        | The language of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| generateRecurrenceToken                       | boolean    | N        | Determines if a recurrence token should be generated. A recurrence token is primarily used to enable recurring payments through server-to-server calls. Default value is false                                                                                                                                                                                                                                                                                                                                     |
+| urls.hostUrls                                 | array      | Y        | The array of URIs valid for embedding of PayEx Hosted Views.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.completeUrl                              | string     | Y        | The URI to redirect the payer to once the payment is completed.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.cancelUrl                                | string     | N        | The URI to redirect the payer to if the payment is canceled.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.paymentUrl                               | string     | N        | The URI that PayEx will redirect back to when the payment menu needs to be loaded, to inspect and act on the current status of the payment. Only used in hosted views. Can not be used simultaneously with cancelUrl; only cancelUrl or paymentUrl can be used, not both.                                                                                                                                                                                                                                          |
+| urls.callbackUrl                              | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| urls.termsOfServiceUrl                        | string     | Y        | The URI to the terms of service document the payer must accept in order to complete the payment. Require https.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.logoUrl                                  | string     | Y        | The URI to the logo that will be displayed on redirect pages. Require https.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| payeeInfo.payeeId                             | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| payeeInfo.payeeReference                      | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                                                                                                                                                                                                                                                                                                                                              |
+| payeeInfo.payeeName                           | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| payeeInfo.productCategory                     | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process.                                                                                                                                                                                                                                                                                                                            |
+| payeeInfo.subsite                             | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                                                                                                                                                                                                                                                                                                                                               |
+| payeeInfo.orderReference                      | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| payer.nationalIdentifier                      | object     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.socialSecurityNumber | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.countryCode          | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.firstName                               | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.lastName                                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.email                                   | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.msisdn                                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.homePhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.workPhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.firstName               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.lastName                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.streetAddress           | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.coAddress               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.city                    | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.zipCode                 | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.countryCode             | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.firstName                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.lastName                 | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.streetAddress            | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.coAddress                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.city                     | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.zipCode                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.countryCode              | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| accountInfo                                   | object     | N        | Optional. If payer is known by merchant and have some kind of registered user then these fields can be set.                                                                                                                                                                                                                                                                                                                                                                                                        |
+| accountInfo.accountAgeIndicator               | string     | N        | Indicates the length of time that the payments account was enrolled in the cardholder's account with merchant.01 (No account, guest)02 (Created during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                     |
+| accountInfo.accountChangeIndicator            | string     | N        | Length of time since the cardholder's account information with the merchant was changed. Including billing etc.01 (Changed during transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                          |
+| accountInfo.accountPwdChangeIndicator         | string     | N        | Indicates the length of time since the cardholder's account with the merchant had a password change or account reset.01 (No change)02 (Changed during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                      |
+| accountInfo.shippingAddressUsageIndicator     | string     | N        | Indicates when the shipping address used for this transaction was first used with the merchant.01 (This transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                                                    |
+| accountInfo.shippingNameIndicator             | string     | N        | Indicates if the Cardholder Name on the account is identical to the shipping Name used for this transaction.01 (Account name identical to shipping name)02 (Account name different than shipping name)                                                                                                                                                                                                                                                                                                             |
+| accountInfo.suspiciousAccountActivity         | string     | N        | Indicates whether merchant has experienced suspicious activity (including previous fraud) on the cardholder account.01 (No suspicious activity has been observed)02 (Suspicious activity has been observed)                                                                                                                                                                                                                                                                                                        |
+| accountInfo.addressMatchIndicator             | boolean    | N        | Allows the 3DS Requestor to indicate to the ACS whether the cardholder’s billing and shipping address are the same.                                                                                                                                                                                                                                                                                                                                                                                                |
+| riskIndicator.deliveryEmailAddress            | string     | N        | For electronic delivery, the email address to which the merchandise was delivered.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| riskIndicator.deliveryTimeFrameIndicator      | string     | N        | Indicates the merchandise delivery timeframe.01 (Electronic Delivery)02 (Same day shipping)03 (Overnight shipping)04 (Two-day or more shipping)                                                                                                                                                                                                                                                                                                                                                                    |
+| riskIndicator.preOrderDate                    | string     | N        | For a pre-ordered purchase. The expected date that the merchandise will be available.FORMAT: "YYYYMMDD"                                                                                                                                                                                                                                                                                                                                                                                                            |
+| riskIndicator.preOrderPurchaseIndicator       | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.shipIndicator                   | string     | N        | Indicates shipping method chosen for the transaction.01 (Ship to cardholder's billing address)02 (Ship to another verified address on file with merchant)03 (Ship to address that is different than cardholder's billing address)04 (Ship to Store / Pick-up at local store. Store address shall be populated in shipping address fields)05 (Digital goods, includes online services, electronic giftcards and redemption codes)06 (Travel and Event tickets, not shipped)07 (Other, e.g. gaming, digital service) |
+| riskIndicator.giftCardPurchase                | boolean    | N        | true if this is a purchase of a gift card.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| riskIndicator.reOrderPurchaseIndicator        | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.pickUpAddress                   | object     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.name              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.streetAddress     | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.coAddress         | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.city              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.zipCode           | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.countryCode       | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| metadata                                      | object     | N        | The keys and values that should be associated with the payment order. Can be additional identifiers and data you want to associate with the payment.                                                                                                                                                                                                                                                                                                                                                               |
+| items                                         | array      | N        | The array of items that will affect how the payment is performed.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| items.creditCard.rejectDebitCards             | boolean    | N        | true if debit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                             |
+| items.creditCard.rejectCreditCards            | boolean    | N        | true if credit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                            |
+| items.creditCard.rejectConsumerCards          | boolean    | N        | true if consumer cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                          |
+| items.creditCard.rejectCorporateCards         | boolean    | N        | true if corporate cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                         |
+| items.invoice.feeAmount                       | integer    | N        | The fee amount in the lowest monetary unit to apply if the consumer chooses to pay with invoice.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| items.swish.enableEcomOnly                    | boolean    | N        | true to only enable Swish on ecommerce transactions.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "created": "2016-09-14T13:21:29.3182115Z",
+    "updated": "2016-09-14T13:21:57.6627579Z",
+    "state": "Ready",
+    "operation": "Purchase",
+    "intent": "Authorization",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "remainingCaptureAmount": 1500,
+    "remainingCancellationAmount": 1500,
+    "remainingReversalAmount": 0,
+    "description": "Test Purchase",
+    "initiatingSystemUserAgent": "PostmanRuntime/3.0.1",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+    "payeeInfo" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+    "settings": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" },
+    "payers": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payers" },
+    "payments": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payments" },
+    "items": [
+      {
+        "creditCard": {
+          "cardBrands": [ "Visa", "MasterCard", "Ica", "etc..." ]
+        }
+      },
+      { "invoice": {} },
+      { "campaignInvoice": {} },
+      { "swish": {} },
+      { "vipps": {} }
+    ]
+  },
+  "operations": [
+    {
+      "href": "https://ecom.payex.com/paymentorders/123456123412341234123456789012",
+      "rel": "redirect-paymentorder",
+      "method": "GET",
+      "contentType": "application/json"
+    },
+    {
+      "href": "https://ecom.dev.payex.com/paymentmenu/scripts/client/client-paymentmenu.js",
+      "rel": "view-paymentorder",
+      "method": "GET",
+      "contentType": "application/javascript"
+    }
+  ]
+}
+```
+
+### 5.2 Recurring Payment Merchant One
+
+When the consumer has completed their payment in the created payment order from 5.1, you are able to retrieve the recurrenceToken from the payment order. Only available to use by Merchant One.
+
+{:.code-header}
+**Request**
+```http
+GET /psp/paymentorders/<paymentOrderId>/currentpayment HTTP/1.1
+Host: api.payex.com
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+```
+
+{:.code-header}
+**Response**
+```http 
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "paymentorder": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "recurrenceToken": "5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "menuElementName": "creditcard",
+    "payment": {
+        "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "number": 1234567890,
+        "instrument": "CreditCard",
+        "created": "2016-09-14T13:21:29.3182115Z",
+        "updated": "2016-09-14T13:21:57.6627579Z",
+        "operation": "Purchase",
+        "intent": "Authorization",
+        "state": "Ready",
+        "currency": "SEK",
+        "amount": 1500,
+        "remainingCaptureAmount": 1500,
+        "remainingCancellationAmount": 1500,
+        "remainingReversalAmount": 0,
+        "description": "Test Purchase",
+        "payerReference": "AB1234",
+        "initiatingSystemUserAgent": "PostmanRuntime/3.0.1",
+        "userAgent": "Mozilla/5.0...",
+        "language": "sv-SE",
+        "paymentToken": "5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "prices": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/prices" },
+        "transactions": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions" },
+        "authorizations": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/authorizations" },
+        "captures": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/captures" },
+        "cancellations": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/cancellations" },
+        "reversals": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/reversals" },
+        "verifications": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/verifications" },
+        "urls" : { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+        "payeeInfo" : { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+        "metadata" : { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/metadata" },
+        "settings": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" }
+    },
+    "operations": []
+}
+```
+
+**Create a recurring payment for Merchant One**  
+When you have a recurrence token safely tucked away, you can use this token in a subsequent Recur payment. This will be a server-to-server affair, as we have tied all necessary payment instrument details related to the recurrence token during the initial payment order.
+
+{:.code-header}
+**Request Merchant One**
+```http
+POST /psp/paymentorders HTTP/1.1
+Host: api.payex.com
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Recur",
+    "intent": "Authorization",
+    "recurrenceToken": "5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Recurrence",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls": {
+      "callbackUrl": "http://test-dummy.net/payment-callback"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant1",
+      "productCategory": "A123",
+      "orderReference": "orderRef123",
+      "subsite": "MySubsite"       
+    }
+  }
+}
+```
+
+{:.table.table-striped}
+| Property                  | Type       | Required | Description                                                                                                                                                                             |
+|---------------------------|------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder              | object     | Y        | The payment order object.                                                                                                                                                               |
+| operation                 | string     | Y        | Recur is always used for recurring payments.                                                                                                                                            |
+| intent                    | string     | Y        | The intent of the payment.                                                                                                                                                              |
+| recurrenceToken           | string     | Y        | The reccurenceToken to debit.                                                                                                                                                           |
+| currency                  | string     | Y        | The currency of the payment.                                                                                                                                                            |
+| amount                    | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                           |
+| vatAmount                 | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                  |
+| description               | string     | Y        | The description of the payment order.                                                                                                                                                   |
+| userAgent                 | string     | Y        | The user agent of the payer.                                                                                                                                                            |
+| language                  | string     | Y        | The language of the payer.                                                                                                                                                              |
+| urls.callbackUrl          | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                               |
+| payeeInfo.payeeId         | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                           |
+| payeeInfo.payeeReference  | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                   |
+| payeeInfo.payeeName       | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                |
+| payeeInfo.productCategory | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process. |
+| payeeInfo.orderReference  | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                 |
+| payeeInfo.subsite         | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                    |
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "created": "2016-09-14T13:21:29.3182115Z",
+    "updated": "2016-09-14T13:21:57.6627579Z",
+    "state": "Ready",
+    "operation": "Recur",
+    "intent": "Authorization",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "remainingCaptureAmount": 1500,
+    "remainingCancellationAmount": 1500,
+    "remainingReversalAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+    "payeeInfo" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+    "settings": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" },
+    "payers": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payers" },
+    "payments": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payments" },
+    "items": [
+      {
+        "creditCard": {
+          "cardBrands": [ "Visa", "MasterCard", "Ica", "etc..." ]
+        }
+      },
+      { "invoice": {} },
+      { "campaignInvoice": {} },
+      { "swish": {} },
+      { "vipps": {} }
+    ]
+  },
+  "operations":  [
+      {
+      }
+  ]
+}
+```
+
+### 5.3 Stored Card Payment Order Merchant One
+
+If the consumer chose to store their card in the previous payment order created in [5.1 Create Payment Order](#51-create-payment-order---merchant-one) you can create a new payment order and the consumers card will be presented in the payment menu.
+
+**Important!** Use Operation Purchase when creating a payment order that should debit the consumer as Verify will not debit any amount.
+Set generateRecurrenceToken value to **false** as you've already created a recurrenceToken for the consumer.
+
+Example follows Create Payment Order [1.2 Use Case: PayEx Checkout - Merchant onboarding](#12-use-case-payex-checkout---merchant-onboarding)
+
+{:.code-header}
+**Request**
+```http
+POST /psp/paymentorders HTTP/1.1
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Purchase",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",                                 
+    "language": "sv-SE",
+    "generateRecurrenceToken": false,                         
+    "disablePaymentMenu": false,                              
+    "urls": {
+      "hostUrls": [ "http://test-dummy.net", "http://test-dummy2.net" ],
+      "completeUrl": "http://test-dummy.net/payment-completed",
+      "cancelUrl": "http://test-dummy.net/payment-canceled",
+      "paymentUrl": "http://test-dummy.net/payment",
+      "callbackUrl": "http://test-dummy.net/payment-callback",     
+      "termsOfServiceUrl": "http://test-dummy.net/termsandconditoons.pdf",
+      "logoUrl": "http://test-dummy.net/logo.png"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant1",                                    
+      "productCategory": "A123",                                   
+      "subsite": "MySubsite",                                       
+      "orderReference" : "or-123456"                               
+    },
+    "payer": {
+      "nationalIdentifier": {                                      
+        "socialSecurityNumber": "19XXXXXXXXXX",
+        "countryCode": "SE"
+      },
+      "firstName": "string",                      
+      "lastName": "string",                 
+      "email": "string",      
+      "msisdn": "string",                 
+      "workPhoneNumber" : "string",                        
+      "homePhoneNumber" : "string",                        
+      "shippingAddress" : {                    
+        "firstName" : "firstname/companyname", 
+        "lastName" : "lastname",               
+        "email": "string",       
+        "msisdn": "string",      
+        "streetAddress" : "string",      
+        "coAddress" : "string",          
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "billingAddress" : {                      
+        "firstName" : "firstname/companyname",  
+        "lastName" : "lastname",                
+        "email": "string",      
+        "msisdn": "string",                
+        "streetAddress" : "string",        
+        "coAddress" : "string",            
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "accountInfo" : {                                 
+        "accountAgeIndicator" : "01",       
+        "accountChangeIndicator" : "01",       
+        "accountPwdChangeIndicator" : "01", 
+        "shippingAddressUsageIndicator" : "01",
+        "shippingNameIndicator" : "01",              
+        "suspiciousAccountActivity" : "01",        
+        "addressMatchIndicator": "false"           
+      }
+     },
+    "riskIndicator" : {
+       "deliveryEmailAddress" : "string",               
+       "deliveryTimeFrameindicator" : "01",    
+       "preOrderDate" : "YYYYMMDD",                     
+       "preOrderPurchaseIndicator" : "01",           
+       "shipIndicator" : "01",        
+       "giftCardPurchase" : "false",               
+       "reOrderPurchaseIndicator" : "01",            
+       "pickUpAddress" : {                              
+           "name" : "companyname",                      
+           "streetAddress" : "string",                  
+           "coAddress" : "string",                      
+           "city" : "string",
+           "zipCode" : "string",
+           "countryCode" : "string"
+       }
+    },
+    "metadata": {                                          
+      "key1": "value1",
+      "key2": 2,
+      "key3": 3.1,
+      "key4": false
+    },
+    "items": [                                             
+    {
+      "creditCard": {
+        "rejectCreditCards": false,                   
+        "rejectDebitCards": false,                    
+        "rejectConsumerCards": false,                 
+        "rejectCorporateCards": false                 
+      }
+    },
+    {
+      "invoice": {
+        "feeAmount" : 1900
+      }
+    },
+    {
+      "campaignInvoice": {
+        "campaignCode" : "Campaign1",
+        "feeAmount" : 2900 
+      }
+    },
+    {
+      "swish": {
+        "EnableEcomOnly": false                 
+      }
+    }
+   ]
+  }
+}
+```
+
+{:.table.table-striped}
+| Property                                      | Type       | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+|-----------------------------------------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder                                  | object     | Y        | The payment order object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| operation                                     | string     | Y        | The operation that the payment order is supposed to perform.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| currency                                      | string     | Y        | The currency of the payment.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| amount                                        | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                      |
+| vatAmount                                     | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                             |
+| description                                   | string     | Y        | The description of the payment order.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| userAgent                                     | string     | N        | The user agent of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| language                                      | string     | Y        | The language of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| generateRecurrenceToken                       | boolean    | N        | Determines if a recurrence token should be generated. A recurrence token is primarily used to enable recurring payments through server-to-server calls. Default value is false                                                                                                                                                                                                                                                                                                                                     |
+| urls.hostUrls                                 | array      | Y        | The array of URIs valid for embedding of PayEx Hosted Views.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.completeUrl                              | string     | Y        | The URI to redirect the payer to once the payment is completed.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.cancelUrl                                | string     | N        | The URI to redirect the payer to if the payment is canceled.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.paymentUrl                               | string     | N        | The URI that PayEx will redirect back to when the payment menu needs to be loaded, to inspect and act on the current status of the payment. Only used in hosted views. Can not be used simultaneously with cancelUrl; only cancelUrl or paymentUrl can be used, not both.                                                                                                                                                                                                                                          |
+| urls.callbackUrl                              | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| urls.termsOfServiceUrl                        | string     | Y        | The URI to the terms of service document the payer must accept in order to complete the payment. Require https.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.logoUrl                                  | string     | Y        | The URI to the logo that will be displayed on redirect pages. Require https.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| payeeInfo.payeeId                             | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| payeeInfo.payeeReference                      | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                                                                                                                                                                                                                                                                                                                                              |
+| payeeInfo.payeeName                           | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| payeeInfo.productCategory                     | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process.                                                                                                                                                                                                                                                                                                                            |
+| payeeInfo.subsite                             | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                                                                                                                                                                                                                                                                                                                                               |
+| payeeInfo.orderReference                      | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| payer.nationalIdentifier                      | object     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.socialSecurityNumber | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.countryCode          | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.firstName                               | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.lastName                                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.email                                   | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.msisdn                                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.homePhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.workPhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.firstName               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.lastName                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.streetAddress           | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.coAddress               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.city                    | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.zipCode                 | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.countryCode             | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.firstName                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.lastName                 | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.streetAddress            | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.coAddress                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.city                     | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.zipCode                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.countryCode              | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| accountInfo                                   | object     | N        | Optional. If payer is known by merchant and have some kind of registered user then these fields can be set.                                                                                                                                                                                                                                                                                                                                                                                                        |
+| accountInfo.accountAgeIndicator               | string     | N        | Indicates the length of time that the payments account was enrolled in the cardholder's account with merchant.01 (No account, guest)02 (Created during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                     |
+| accountInfo.accountChangeIndicator            | string     | N        | Length of time since the cardholder's account information with the merchant was changed. Including billing etc.01 (Changed during transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                          |
+| accountInfo.accountPwdChangeIndicator         | string     | N        | Indicates the length of time since the cardholder's account with the merchant had a password change or account reset.01 (No change)02 (Changed during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                      |
+| accountInfo.shippingAddressUsageIndicator     | string     | N        | Indicates when the shipping address used for this transaction was first used with the merchant.01 (This transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                                                    |
+| accountInfo.shippingNameIndicator             | string     | N        | Indicates if the Cardholder Name on the account is identical to the shipping Name used for this transaction.01 (Account name identical to shipping name)02 (Account name different than shipping name)                                                                                                                                                                                                                                                                                                             |
+| accountInfo.suspiciousAccountActivity         | string     | N        | Indicates whether merchant has experienced suspicious activity (including previous fraud) on the cardholder account.01 (No suspicious activity has been observed)02 (Suspicious activity has been observed)                                                                                                                                                                                                                                                                                                        |
+| accountInfo.addressMatchIndicator             | boolean    | N        | Allows the 3DS Requestor to indicate to the ACS whether the cardholder’s billing and shipping address are the same.                                                                                                                                                                                                                                                                                                                                                                                                |
+| riskIndicator.deliveryEmailAddress            | string     | N        | For electronic delivery, the email address to which the merchandise was delivered.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| riskIndicator.deliveryTimeFrameIndicator      | string     | N        | Indicates the merchandise delivery timeframe.01 (Electronic Delivery)02 (Same day shipping)03 (Overnight shipping)04 (Two-day or more shipping)                                                                                                                                                                                                                                                                                                                                                                    |
+| riskIndicator.preOrderDate                    | string     | N        | For a pre-ordered purchase. The expected date that the merchandise will be available.FORMAT: "YYYYMMDD"                                                                                                                                                                                                                                                                                                                                                                                                            |
+| riskIndicator.preOrderPurchaseIndicator       | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.shipIndicator                   | string     | N        | Indicates shipping method chosen for the transaction.01 (Ship to cardholder's billing address)02 (Ship to another verified address on file with merchant)03 (Ship to address that is different than cardholder's billing address)04 (Ship to Store / Pick-up at local store. Store address shall be populated in shipping address fields)05 (Digital goods, includes online services, electronic giftcards and redemption codes)06 (Travel and Event tickets, not shipped)07 (Other, e.g. gaming, digital service) |
+| riskIndicator.giftCardPurchase                | boolean    | N        | true if this is a purchase of a gift card.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| riskIndicator.reOrderPurchaseIndicator        | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.pickUpAddress                   | object     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.name              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.streetAddress     | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.coAddress         | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.city              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.zipCode           | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.countryCode       | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| metadata                                      | object     | N        | The keys and values that should be associated with the payment order. Can be additional identifiers and data you want to associate with the payment.                                                                                                                                                                                                                                                                                                                                                               |
+| items                                         | array      | N        | The array of items that will affect how the payment is performed.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| items.creditCard.rejectDebitCards             | boolean    | N        | true if debit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                             |
+| items.creditCard.rejectCreditCards            | boolean    | N        | true if credit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                            |
+| items.creditCard.rejectConsumerCards          | boolean    | N        | true if consumer cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                          |
+| items.creditCard.rejectCorporateCards         | boolean    | N        | true if corporate cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                         |
+| items.invoice.feeAmount                       | integer    | N        | The fee amount in the lowest monetary unit to apply if the consumer chooses to pay with invoice.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| items.swish.enableEcomOnly                    | boolean    | N        | true to only enable Swish on ecommerce transactions.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "created": "2016-09-14T13:21:29.3182115Z",
+    "updated": "2016-09-14T13:21:57.6627579Z",
+    "state": "Ready",
+    "operation": "Purchase",
+    "intent": "Authorization",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "remainingCaptureAmount": 1500,
+    "remainingCancellationAmount": 1500,
+    "remainingReversalAmount": 0,
+    "description": "Test Purchase",
+    "initiatingSystemUserAgent": "PostmanRuntime/3.0.1",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+    "payeeInfo" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+    "settings": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" },
+    "payers": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payers" },
+    "payments": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payments" },
+    "items": [
+      {
+        "creditCard": {
+          "cardBrands": [ "Visa", "MasterCard", "Ica", "etc..." ]
+        }
+      },
+      { "invoice": {} },
+      { "campaignInvoice": {} },
+      { "swish": {} },
+      { "vipps": {} }
+    ]
+  },
+  "operations": [
+    {
+      "href": "https://ecom.payex.com/paymentorders/123456123412341234123456789012",
+      "rel": "redirect-paymentorder",
+      "method": "GET",
+      "contentType": "application/json"
+    },
+    {
+      "href": "https://ecom.dev.payex.com/paymentmenu/scripts/client/client-paymentmenu.js",
+      "rel": "view-paymentorder",
+      "method": "GET",
+      "contentType": "application/javascript"
+    }
+  ]
+}
+```
+
+### 5.4 Stored Card Payment Order Merchant Two
+
+Merchant Two wants to create a payment order for the same consumer as Merchant One in 5.1 but doesn't want to create a recurrenceToken as recurring payments isn't needed. The consumer will have their stored card from 5.1 available to use in the payment menu.
+
+Set generateRecurrenceToken value to **false**
+
+Example follows Create Payment Order [1.2 Use Case: PayEx Checkout - Merchant onboarding](#12-use-case-payex-checkout---merchant-onboarding)
+
+{:.code-header}
+**Request**
+```http
+POST /psp/paymentorders HTTP/1.1
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Purchase",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",                                 
+    "language": "sv-SE",
+    "generateRecurrenceToken": false,                         
+    "disablePaymentMenu": false,                              
+    "urls": {
+      "hostUrls": [ "http://test-dummy.net", "http://test-dummy2.net" ],
+      "completeUrl": "http://test-dummy.net/payment-completed",
+      "cancelUrl": "http://test-dummy.net/payment-canceled",
+      "paymentUrl": "http://test-dummy.net/payment",
+      "callbackUrl": "http://test-dummy.net/payment-callback",     
+      "termsOfServiceUrl": "http://test-dummy.net/termsandconditoons.pdf",
+      "logoUrl": "http://test-dummy.net/logo.png"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant1",                                    
+      "productCategory": "A123",                                   
+      "subsite": "MySubsite",                                       
+      "orderReference" : "or-123456"                               
+    },
+    "payer": {
+      "nationalIdentifier": {                                      
+        "socialSecurityNumber": "19XXXXXXXXXX",
+        "countryCode": "SE"
+      },
+      "firstName": "string",                      
+      "lastName": "string",                 
+      "email": "string",      
+      "msisdn": "string",                 
+      "workPhoneNumber" : "string",                        
+      "homePhoneNumber" : "string",                        
+      "shippingAddress" : {                    
+        "firstName" : "firstname/companyname", 
+        "lastName" : "lastname",               
+        "email": "string",       
+        "msisdn": "string",      
+        "streetAddress" : "string",      
+        "coAddress" : "string",          
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "billingAddress" : {                      
+        "firstName" : "firstname/companyname",  
+        "lastName" : "lastname",                
+        "email": "string",      
+        "msisdn": "string",                
+        "streetAddress" : "string",        
+        "coAddress" : "string",            
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "accountInfo" : {                                 
+        "accountAgeIndicator" : "01",       
+        "accountChangeIndicator" : "01",       
+        "accountPwdChangeIndicator" : "01", 
+        "shippingAddressUsageIndicator" : "01",
+        "shippingNameIndicator" : "01",              
+        "suspiciousAccountActivity" : "01",        
+        "addressMatchIndicator": "false"           
+      }
+     },
+    "riskIndicator" : {
+       "deliveryEmailAddress" : "string",               
+       "deliveryTimeFrameindicator" : "01",    
+       "preOrderDate" : "YYYYMMDD",                     
+       "preOrderPurchaseIndicator" : "01",           
+       "shipIndicator" : "01",        
+       "giftCardPurchase" : "false",               
+       "reOrderPurchaseIndicator" : "01",            
+       "pickUpAddress" : {                              
+           "name" : "companyname",                      
+           "streetAddress" : "string",                  
+           "coAddress" : "string",                      
+           "city" : "string",
+           "zipCode" : "string",
+           "countryCode" : "string"
+       }
+    },
+    "metadata": {                                          
+      "key1": "value1",
+      "key2": 2,
+      "key3": 3.1,
+      "key4": false
+    },
+    "items": [                                             
+    {
+      "creditCard": {
+        "rejectCreditCards": false,                   
+        "rejectDebitCards": false,                    
+        "rejectConsumerCards": false,                 
+        "rejectCorporateCards": false                 
+      }
+    },
+    {
+      "invoice": {
+        "feeAmount" : 1900
+      }
+    },
+    {
+      "campaignInvoice": {
+        "campaignCode" : "Campaign1",
+        "feeAmount" : 2900 
+      }
+    },
+    {
+      "swish": {
+        "EnableEcomOnly": false                 
+      }
+    }
+   ]
+  }
+}
+```
+
+{:.table.table-striped}
+| Property                                      | Type       | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+|-----------------------------------------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder                                  | object     | Y        | The payment order object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| operation                                     | string     | Y        | The operation that the payment order is supposed to perform.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| currency                                      | string     | Y        | The currency of the payment.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| amount                                        | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                      |
+| vatAmount                                     | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                             |
+| description                                   | string     | Y        | The description of the payment order.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| userAgent                                     | string     | N        | The user agent of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| language                                      | string     | Y        | The language of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| generateRecurrenceToken                       | boolean    | N        | Determines if a recurrence token should be generated. A recurrence token is primarily used to enable recurring payments through server-to-server calls. Default value is false                                                                                                                                                                                                                                                                                                                                     |
+| urls.hostUrls                                 | array      | Y        | The array of URIs valid for embedding of PayEx Hosted Views.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.completeUrl                              | string     | Y        | The URI to redirect the payer to once the payment is completed.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.cancelUrl                                | string     | N        | The URI to redirect the payer to if the payment is canceled.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.paymentUrl                               | string     | N        | The URI that PayEx will redirect back to when the payment menu needs to be loaded, to inspect and act on the current status of the payment. Only used in hosted views. Can not be used simultaneously with cancelUrl; only cancelUrl or paymentUrl can be used, not both.                                                                                                                                                                                                                                          |
+| urls.callbackUrl                              | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| urls.termsOfServiceUrl                        | string     | Y        | The URI to the terms of service document the payer must accept in order to complete the payment. Require https.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.logoUrl                                  | string     | Y        | The URI to the logo that will be displayed on redirect pages. Require https.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| payeeInfo.payeeId                             | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| payeeInfo.payeeReference                      | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                                                                                                                                                                                                                                                                                                                                              |
+| payeeInfo.payeeName                           | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| payeeInfo.productCategory                     | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process.                                                                                                                                                                                                                                                                                                                            |
+| payeeInfo.subsite                             | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                                                                                                                                                                                                                                                                                                                                               |
+| payeeInfo.orderReference                      | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| payer.nationalIdentifier                      | object     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.socialSecurityNumber | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.countryCode          | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.firstName                               | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.lastName                                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.email                                   | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.msisdn                                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.homePhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.workPhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.firstName               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.lastName                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.streetAddress           | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.coAddress               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.city                    | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.zipCode                 | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.countryCode             | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.firstName                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.lastName                 | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.streetAddress            | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.coAddress                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.city                     | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.zipCode                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.countryCode              | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| accountInfo                                   | object     | N        | Optional. If payer is known by merchant and have some kind of registered user then these fields can be set.                                                                                                                                                                                                                                                                                                                                                                                                        |
+| accountInfo.accountAgeIndicator               | string     | N        | Indicates the length of time that the payments account was enrolled in the cardholder's account with merchant.01 (No account, guest)02 (Created during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                     |
+| accountInfo.accountChangeIndicator            | string     | N        | Length of time since the cardholder's account information with the merchant was changed. Including billing etc.01 (Changed during transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                          |
+| accountInfo.accountPwdChangeIndicator         | string     | N        | Indicates the length of time since the cardholder's account with the merchant had a password change or account reset.01 (No change)02 (Changed during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                      |
+| accountInfo.shippingAddressUsageIndicator     | string     | N        | Indicates when the shipping address used for this transaction was first used with the merchant.01 (This transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                                                    |
+| accountInfo.shippingNameIndicator             | string     | N        | Indicates if the Cardholder Name on the account is identical to the shipping Name used for this transaction.01 (Account name identical to shipping name)02 (Account name different than shipping name)                                                                                                                                                                                                                                                                                                             |
+| accountInfo.suspiciousAccountActivity         | string     | N        | Indicates whether merchant has experienced suspicious activity (including previous fraud) on the cardholder account.01 (No suspicious activity has been observed)02 (Suspicious activity has been observed)                                                                                                                                                                                                                                                                                                        |
+| accountInfo.addressMatchIndicator             | boolean    | N        | Allows the 3DS Requestor to indicate to the ACS whether the cardholder’s billing and shipping address are the same.                                                                                                                                                                                                                                                                                                                                                                                                |
+| riskIndicator.deliveryEmailAddress            | string     | N        | For electronic delivery, the email address to which the merchandise was delivered.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| riskIndicator.deliveryTimeFrameIndicator      | string     | N        | Indicates the merchandise delivery timeframe.01 (Electronic Delivery)02 (Same day shipping)03 (Overnight shipping)04 (Two-day or more shipping)                                                                                                                                                                                                                                                                                                                                                                    |
+| riskIndicator.preOrderDate                    | string     | N        | For a pre-ordered purchase. The expected date that the merchandise will be available.FORMAT: "YYYYMMDD"                                                                                                                                                                                                                                                                                                                                                                                                            |
+| riskIndicator.preOrderPurchaseIndicator       | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.shipIndicator                   | string     | N        | Indicates shipping method chosen for the transaction.01 (Ship to cardholder's billing address)02 (Ship to another verified address on file with merchant)03 (Ship to address that is different than cardholder's billing address)04 (Ship to Store / Pick-up at local store. Store address shall be populated in shipping address fields)05 (Digital goods, includes online services, electronic giftcards and redemption codes)06 (Travel and Event tickets, not shipped)07 (Other, e.g. gaming, digital service) |
+| riskIndicator.giftCardPurchase                | boolean    | N        | true if this is a purchase of a gift card.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| riskIndicator.reOrderPurchaseIndicator        | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.pickUpAddress                   | object     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.name              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.streetAddress     | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.coAddress         | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.city              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.zipCode           | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.countryCode       | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| metadata                                      | object     | N        | The keys and values that should be associated with the payment order. Can be additional identifiers and data you want to associate with the payment.                                                                                                                                                                                                                                                                                                                                                               |
+| items                                         | array      | N        | The array of items that will affect how the payment is performed.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| items.creditCard.rejectDebitCards             | boolean    | N        | true if debit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                             |
+| items.creditCard.rejectCreditCards            | boolean    | N        | true if credit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                            |
+| items.creditCard.rejectConsumerCards          | boolean    | N        | true if consumer cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                          |
+| items.creditCard.rejectCorporateCards         | boolean    | N        | true if corporate cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                         |
+| items.invoice.feeAmount                       | integer    | N        | The fee amount in the lowest monetary unit to apply if the consumer chooses to pay with invoice.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| items.swish.enableEcomOnly                    | boolean    | N        | true to only enable Swish on ecommerce transactions.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "created": "2016-09-14T13:21:29.3182115Z",
+    "updated": "2016-09-14T13:21:57.6627579Z",
+    "state": "Ready",
+    "operation": "Purchase",
+    "intent": "Authorization",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "remainingCaptureAmount": 1500,
+    "remainingCancellationAmount": 1500,
+    "remainingReversalAmount": 0,
+    "description": "Test Purchase",
+    "initiatingSystemUserAgent": "PostmanRuntime/3.0.1",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+    "payeeInfo" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+    "settings": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" },
+    "payers": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payers" },
+    "payments": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payments" },
+    "items": [
+      {
+        "creditCard": {
+          "cardBrands": [ "Visa", "MasterCard", "Ica", "etc..." ]
+        }
+      },
+      { "invoice": {} },
+      { "campaignInvoice": {} },
+      { "swish": {} },
+      { "vipps": {} }
+    ]
+  },
+  "operations": [
+    {
+      "href": "https://ecom.payex.com/paymentorders/123456123412341234123456789012",
+      "rel": "redirect-paymentorder",
+      "method": "GET",
+      "contentType": "application/json"
+    },
+    {
+      "href": "https://ecom.dev.payex.com/paymentmenu/scripts/client/client-paymentmenu.js",
+      "rel": "view-paymentorder",
+      "method": "GET",
+      "contentType": "application/javascript"
+    }
+  ]
+}
+```
+
+### 5.5 Stored Card Payment Order Merchant Three
+
+Merchant Three wants to create a payment order for the same consumer as Merchant One in 5.1 and Merchant Two in 5.4 but in addition wants to generate their own recurrenceToken for recurring payments. The consumer will have their stored card from 5.1 available to use in the payment menu.
+
+Set generateRecurrenceToken value to **true**
+
+Example follows Create Payment Order [1.2 Use Case: PayEx Checkout - Merchant onboarding](#12-use-case-payex-checkout---merchant-onboarding)
+
+{:.code-header}
+**Request**
+```http
+POST /psp/paymentorders HTTP/1.1
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Purchase",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",                                 
+    "language": "sv-SE",
+    "generateRecurrenceToken": true,                         
+    "disablePaymentMenu": false,                              
+    "urls": {
+      "hostUrls": [ "http://test-dummy.net", "http://test-dummy2.net" ],
+      "completeUrl": "http://test-dummy.net/payment-completed",
+      "cancelUrl": "http://test-dummy.net/payment-canceled",
+      "paymentUrl": "http://test-dummy.net/payment",
+      "callbackUrl": "http://test-dummy.net/payment-callback",     
+      "termsOfServiceUrl": "http://test-dummy.net/termsandconditoons.pdf",
+      "logoUrl": "http://test-dummy.net/logo.png"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant1",                                    
+      "productCategory": "A123",                                   
+      "subsite": "MySubsite",                                       
+      "orderReference" : "or-123456"                               
+    },
+    "payer": {
+      "nationalIdentifier": {                                      
+        "socialSecurityNumber": "19XXXXXXXXXX",
+        "countryCode": "SE"
+      },
+      "firstName": "string",                      
+      "lastName": "string",                 
+      "email": "string",      
+      "msisdn": "string",                 
+      "workPhoneNumber" : "string",                        
+      "homePhoneNumber" : "string",                        
+      "shippingAddress" : {                    
+        "firstName" : "firstname/companyname", 
+        "lastName" : "lastname",               
+        "email": "string",       
+        "msisdn": "string",      
+        "streetAddress" : "string",      
+        "coAddress" : "string",          
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "billingAddress" : {                      
+        "firstName" : "firstname/companyname",  
+        "lastName" : "lastname",                
+        "email": "string",      
+        "msisdn": "string",                
+        "streetAddress" : "string",        
+        "coAddress" : "string",            
+        "city" : "string",
+        "zipCode" : "string",
+        "countryCode" : "string"
+      },
+      "accountInfo" : {                                 
+        "accountAgeIndicator" : "01",       
+        "accountChangeIndicator" : "01",       
+        "accountPwdChangeIndicator" : "01", 
+        "shippingAddressUsageIndicator" : "01",
+        "shippingNameIndicator" : "01",              
+        "suspiciousAccountActivity" : "01",        
+        "addressMatchIndicator": "false"           
+      }
+     },
+    "riskIndicator" : {
+       "deliveryEmailAddress" : "string",               
+       "deliveryTimeFrameindicator" : "01",    
+       "preOrderDate" : "YYYYMMDD",                     
+       "preOrderPurchaseIndicator" : "01",           
+       "shipIndicator" : "01",        
+       "giftCardPurchase" : "false",               
+       "reOrderPurchaseIndicator" : "01",            
+       "pickUpAddress" : {                              
+           "name" : "companyname",                      
+           "streetAddress" : "string",                  
+           "coAddress" : "string",                      
+           "city" : "string",
+           "zipCode" : "string",
+           "countryCode" : "string"
+       }
+    },
+    "metadata": {                                          
+      "key1": "value1",
+      "key2": 2,
+      "key3": 3.1,
+      "key4": false
+    },
+    "items": [                                             
+    {
+      "creditCard": {
+        "rejectCreditCards": false,                   
+        "rejectDebitCards": false,                    
+        "rejectConsumerCards": false,                 
+        "rejectCorporateCards": false                 
+      }
+    },
+    {
+      "invoice": {
+        "feeAmount" : 1900
+      }
+    },
+    {
+      "campaignInvoice": {
+        "campaignCode" : "Campaign1",
+        "feeAmount" : 2900 
+      }
+    },
+    {
+      "swish": {
+        "EnableEcomOnly": false                 
+      }
+    }
+   ]
+  }
+}
+```
+
+{:.table.table-striped}
+| Property                                      | Type       | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+|-----------------------------------------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder                                  | object     | Y        | The payment order object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| operation                                     | string     | Y        | The operation that the payment order is supposed to perform.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| currency                                      | string     | Y        | The currency of the payment.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| amount                                        | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                      |
+| vatAmount                                     | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                                                                                                                                                                                                                                                                                                                                             |
+| description                                   | string     | Y        | The description of the payment order.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| userAgent                                     | string     | N        | The user agent of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| language                                      | string     | Y        | The language of the payer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| generateRecurrenceToken                       | boolean    | N        | Determines if a recurrence token should be generated. A recurrence token is primarily used to enable recurring payments through server-to-server calls. Default value is false                                                                                                                                                                                                                                                                                                                                     |
+| urls.hostUrls                                 | array      | Y        | The array of URIs valid for embedding of PayEx Hosted Views.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.completeUrl                              | string     | Y        | The URI to redirect the payer to once the payment is completed.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.cancelUrl                                | string     | N        | The URI to redirect the payer to if the payment is canceled.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| urls.paymentUrl                               | string     | N        | The URI that PayEx will redirect back to when the payment menu needs to be loaded, to inspect and act on the current status of the payment. Only used in hosted views. Can not be used simultaneously with cancelUrl; only cancelUrl or paymentUrl can be used, not both.                                                                                                                                                                                                                                          |
+| urls.callbackUrl                              | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| urls.termsOfServiceUrl                        | string     | Y        | The URI to the terms of service document the payer must accept in order to complete the payment. Require https.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| urls.logoUrl                                  | string     | Y        | The URI to the logo that will be displayed on redirect pages. Require https.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| payeeInfo.payeeId                             | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| payeeInfo.payeeReference                      | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                                                                                                                                                                                                                                                                                                                                              |
+| payeeInfo.payeeName                           | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| payeeInfo.productCategory                     | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process.                                                                                                                                                                                                                                                                                                                            |
+| payeeInfo.subsite                             | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                                                                                                                                                                                                                                                                                                                                               |
+| payeeInfo.orderReference                      | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| payer.nationalIdentifier                      | object     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.socialSecurityNumber | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.nationalIdentifier.countryCode          | string     | Y        | Required when merchant onboards consumer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.firstName                               | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.lastName                                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.email                                   | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.msisdn                                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.homePhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.workPhoneNumber                         | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.firstName               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.lastName                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.streetAddress           | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.coAddress               | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.city                    | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.zipCode                 | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.shippingAddress.countryCode             | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.firstName                | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.lastName                 | string     | N        | Optional (increases chance for challenge flow if not set) If buyer is a company, use only firstName for companyName.                                                                                                                                                                                                                                                                                                                                                                                               |
+| payer.billingAddress.streetAddress            | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.coAddress                | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.city                     | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.zipCode                  | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| payer.billingAddress.countryCode              | string     | N        | Optional (increases chance for challenge flow if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| accountInfo                                   | object     | N        | Optional. If payer is known by merchant and have some kind of registered user then these fields can be set.                                                                                                                                                                                                                                                                                                                                                                                                        |
+| accountInfo.accountAgeIndicator               | string     | N        | Indicates the length of time that the payments account was enrolled in the cardholder's account with merchant.01 (No account, guest)02 (Created during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                     |
+| accountInfo.accountChangeIndicator            | string     | N        | Length of time since the cardholder's account information with the merchant was changed. Including billing etc.01 (Changed during transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                          |
+| accountInfo.accountPwdChangeIndicator         | string     | N        | Indicates the length of time since the cardholder's account with the merchant had a password change or account reset.01 (No change)02 (Changed during transaction)03 (Less than 30 days)04 (30-60 days)05 (More than 60 days)                                                                                                                                                                                                                                                                                      |
+| accountInfo.shippingAddressUsageIndicator     | string     | N        | Indicates when the shipping address used for this transaction was first used with the merchant.01 (This transaction)02 (Less than 30 days)03 (30-60 days)04 (More than 60 days)                                                                                                                                                                                                                                                                                                                                    |
+| accountInfo.shippingNameIndicator             | string     | N        | Indicates if the Cardholder Name on the account is identical to the shipping Name used for this transaction.01 (Account name identical to shipping name)02 (Account name different than shipping name)                                                                                                                                                                                                                                                                                                             |
+| accountInfo.suspiciousAccountActivity         | string     | N        | Indicates whether merchant has experienced suspicious activity (including previous fraud) on the cardholder account.01 (No suspicious activity has been observed)02 (Suspicious activity has been observed)                                                                                                                                                                                                                                                                                                        |
+| accountInfo.addressMatchIndicator             | boolean    | N        | Allows the 3DS Requestor to indicate to the ACS whether the cardholder’s billing and shipping address are the same.                                                                                                                                                                                                                                                                                                                                                                                                |
+| riskIndicator.deliveryEmailAddress            | string     | N        | For electronic delivery, the email address to which the merchandise was delivered.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| riskIndicator.deliveryTimeFrameIndicator      | string     | N        | Indicates the merchandise delivery timeframe.01 (Electronic Delivery)02 (Same day shipping)03 (Overnight shipping)04 (Two-day or more shipping)                                                                                                                                                                                                                                                                                                                                                                    |
+| riskIndicator.preOrderDate                    | string     | N        | For a pre-ordered purchase. The expected date that the merchandise will be available.FORMAT: "YYYYMMDD"                                                                                                                                                                                                                                                                                                                                                                                                            |
+| riskIndicator.preOrderPurchaseIndicator       | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.shipIndicator                   | string     | N        | Indicates shipping method chosen for the transaction.01 (Ship to cardholder's billing address)02 (Ship to another verified address on file with merchant)03 (Ship to address that is different than cardholder's billing address)04 (Ship to Store / Pick-up at local store. Store address shall be populated in shipping address fields)05 (Digital goods, includes online services, electronic giftcards and redemption codes)06 (Travel and Event tickets, not shipped)07 (Other, e.g. gaming, digital service) |
+| riskIndicator.giftCardPurchase                | boolean    | N        | true if this is a purchase of a gift card.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| riskIndicator.reOrderPurchaseIndicator        | string     | N        | Indicates whether Cardholder is placing an order for merchandise with a future availability or release date.01 (Merchandise available)02 (Future availability)                                                                                                                                                                                                                                                                                                                                                     |
+| riskIndicator.pickUpAddress                   | object     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.name              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.streetAddress     | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.coAddress         | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.city              | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.zipCode           | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| riskIndicator.pickUpAddress.countryCode       | string     | N        | If shipIndicator set to 4, then prefil this.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| metadata                                      | object     | N        | The keys and values that should be associated with the payment order. Can be additional identifiers and data you want to associate with the payment.                                                                                                                                                                                                                                                                                                                                                               |
+| items                                         | array      | N        | The array of items that will affect how the payment is performed.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| items.creditCard.rejectDebitCards             | boolean    | N        | true if debit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                             |
+| items.creditCard.rejectCreditCards            | boolean    | N        | true if credit cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                            |
+| items.creditCard.rejectConsumerCards          | boolean    | N        | true if consumer cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                          |
+| items.creditCard.rejectCorporateCards         | boolean    | N        | true if corporate cards should be declined; otherwise false per default. Default value is set by PayEx and can be changed at your request.                                                                                                                                                                                                                                                                                                                                                                         |
+| items.invoice.feeAmount                       | integer    | N        | The fee amount in the lowest monetary unit to apply if the consumer chooses to pay with invoice.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| items.swish.enableEcomOnly                    | boolean    | N        | true to only enable Swish on ecommerce transactions.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "created": "2016-09-14T13:21:29.3182115Z",
+    "updated": "2016-09-14T13:21:57.6627579Z",
+    "state": "Ready",
+    "operation": "Purchase",
+    "intent": "Authorization",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "remainingCaptureAmount": 1500,
+    "remainingCancellationAmount": 1500,
+    "remainingReversalAmount": 0,
+    "description": "Test Purchase",
+    "initiatingSystemUserAgent": "PostmanRuntime/3.0.1",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+    "payeeInfo" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+    "settings": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" },
+    "payers": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payers" },
+    "payments": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payments" },
+    "items": [
+      {
+        "creditCard": {
+          "cardBrands": [ "Visa", "MasterCard", "Ica", "etc..." ]
+        }
+      },
+      { "invoice": {} },
+      { "campaignInvoice": {} },
+      { "swish": {} },
+      { "vipps": {} }
+    ]
+  },
+  "operations": [
+    {
+      "href": "https://ecom.payex.com/paymentorders/123456123412341234123456789012",
+      "rel": "redirect-paymentorder",
+      "method": "GET",
+      "contentType": "application/json"
+    },
+    {
+      "href": "https://ecom.dev.payex.com/paymentmenu/scripts/client/client-paymentmenu.js",
+      "rel": "view-paymentorder",
+      "method": "GET",
+      "contentType": "application/javascript"
+    }
+  ]
+}
+```
+
+### 5.6 Recurring Payment Merchant Three
+When the consumer has completed their payment for Merchant Three in the created payment order from 5.5, you are able to retrieve the recurrenceToken from the payment order. Only available to use by Merchant Three.
+
+
+{:.code-header}
+**Request Merchant Three**
+```http
+GET /psp/paymentorders/<paymentOrderId>/currentpayment HTTP/1.1
+Host: api.payex.com
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+```
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "paymentorder": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "recurrenceToken": "5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "menuElementName": "creditcard",
+    "payment": {
+        "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "number": 1234567890,
+        "instrument": "CreditCard",
+        "created": "2016-09-14T13:21:29.3182115Z",
+        "updated": "2016-09-14T13:21:57.6627579Z",
+        "operation": "Purchase",
+        "intent": "Authorization",
+        "state": "Ready",
+        "currency": "SEK",
+        "amount": 1500,
+        "remainingCaptureAmount": 1500,
+        "remainingCancellationAmount": 1500,
+        "remainingReversalAmount": 0,
+        "description": "Test Purchase",
+        "payerReference": "AB1234",
+        "initiatingSystemUserAgent": "PostmanRuntime/3.0.1",
+        "userAgent": "Mozilla/5.0...",
+        "language": "sv-SE",
+        "paymentToken": "5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "prices": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/prices" },
+        "transactions": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions" },
+        "authorizations": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/authorizations" },
+        "captures": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/captures" },
+        "cancellations": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/cancellations" },
+        "reversals": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/reversals" },
+        "verifications": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/verifications" },
+        "urls" : { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+        "payeeInfo" : { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+        "metadata" : { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/metadata" },
+        "settings": { "id": "/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" }
+    },
+    "operations": []
+}
+```
+
+**Create a recurring payment for Merchant Three**  
+When you have a recurrence token safely tucked away, you can use this token in a subsequent Recur payment. This will be a server-to-server affair, as we have tied all necessary payment instrument details related to the recurrence token during the initial payment order.
+
+{:.code-header}
+**Request Merchant Three**
+```http
+POST /psp/paymentorders HTTP/1.1
+Host: api.payex.com
+Authorization: Bearer <MerchantToken>
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "operation": "Recur",
+    "intent": "Authorization",
+    "recurrenceToken": "5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "description": "Test Recurrence",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls": {
+      "callbackUrl": "http://test-dummy.net/payment-callback"
+    },
+    "payeeInfo": {
+      "payeeId": "12345678-1234-1234-1234-123456789012",
+      "payeeReference": "CD1234",
+      "payeeName": "Merchant3",
+      "productCategory": "A123",
+      "orderReference": "orderRef123",
+      "subsite": "MySubsite"       
+    }
+  }
+}
+```
+
+{:.table.table-striped}
+| Property                  | Type       | Required | Description                                                                                                                                                                             |
+|---------------------------|------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| paymentorder              | object     | Y        | The payment order object.                                                                                                                                                               |
+| operation                 | string     | Y        | Recur is always used for recurring payments.                                                                                                                                            |
+| intent                    | string     | Y        | The intent of the payment.                                                                                                                                                              |
+| recurrenceToken           | string     | Y        | The reccurenceToken to debit.                                                                                                                                                           |
+| currency                  | string     | Y        | The currency of the payment.                                                                                                                                                            |
+| amount                    | integer    | Y        | The amount including VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                           |
+| vatAmount                 | integer    | Y        | The amount of VAT in the lowest monetary unit of the currency. E.g. 10000 equals 100.00 NOK and 5000 equals 50.00 NOK.                                                                  |
+| description               | string     | Y        | The description of the payment order.                                                                                                                                                   |
+| userAgent                 | string     | Y        | The user agent of the payer.                                                                                                                                                            |
+| language                  | string     | Y        | The language of the payer.                                                                                                                                                              |
+| urls.callbackUrl          | string     | N        | The URI to the API endpoint receiving POST requests on transaction activity related to the payment order.                                                                               |
+| payeeInfo.payeeId         | string     | Y        | The ID of the payee, usually the merchant ID.                                                                                                                                           |
+| payeeInfo.payeeReference  | string(30) | Y        | A unique reference from the merchant system. It is set per operation to ensure an exactly-once delivery of a transactional operation. See payeeReference for details.                   |
+| payeeInfo.payeeName       | string     | N        | The name of the payee, usually the name of the merchant.                                                                                                                                |
+| payeeInfo.productCategory | string     | N        | A product category or number sent in from the payee/merchant. This is not validated by PayEx, but will be passed through the payment process and may be used in the settlement process. |
+| payeeInfo.orderReference  | string(50) | N        | The order reference should reflect the order reference found in the merchant's systems.                                                                                                 |
+| payeeInfo.subsite         | string(40) | N        | The subsite field can be used to perform split settlement on the payment. The subsites must be resolved with PayEx reconciliation before being used.                                    |
+
+{:.code-header}
+**Response**
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "paymentorder": {
+    "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "created": "2016-09-14T13:21:29.3182115Z",
+    "updated": "2016-09-14T13:21:57.6627579Z",
+    "state": "Ready",
+    "operation": "Recur",
+    "intent": "Authorization",
+    "currency": "SEK",
+    "amount": 1500,
+    "vatAmount": 0,
+    "remainingCaptureAmount": 1500,
+    "remainingCancellationAmount": 1500,
+    "remainingReversalAmount": 0,
+    "description": "Test Purchase",
+    "userAgent": "Mozilla/5.0...",
+    "language": "sv-SE",
+    "urls" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/urls" },
+    "payeeInfo" : { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo" },
+    "settings": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/settings" },
+    "payers": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payers" },
+    "payments": { "id": "/psp/paymentorders/5adc265f-f87f-4313-577e-08d3dca1a26c/payments" },
+    "items": [
+      {
+        "creditCard": {
+          "cardBrands": [ "Visa", "MasterCard", "Ica", "etc..." ]
+        }
+      },
+      { "invoice": {} },
+      { "campaignInvoice": {} },
+      { "swish": {} },
+      { "vipps": {} }
+    ]
+  },
+  "operations":  [
+      {
+      }
+  ]
+}
+```

--- a/checkout/after-payment.md
+++ b/checkout/after-payment.md
@@ -10,6 +10,8 @@ sidebar:
       title: Payment
     - url: /checkout/after-payment
       title: After Payment
+    - url: /checkout/3DS2-documentation
+      title: 3DS2 Documentation
   - title: Resources
     items:
     - url: /resources/

--- a/checkout/after-payment.md
+++ b/checkout/after-payment.md
@@ -10,6 +10,14 @@ sidebar:
       title: Payment
     - url: /checkout/after-payment
       title: After Payment
+  - title: Resources
+    items:
+    - url: /resources/
+      title: Introduction
+    - url: /resources/test-data
+      title: Test Data
+    - url: /resources/demoshop
+      title: Demoshop
 ---
 
 {% include alert.html type="warning"

--- a/checkout/index.md
+++ b/checkout/index.md
@@ -12,6 +12,8 @@ sidebar:
       title: Payment
     - url: /checkout/after-payment
       title: After Payment
+    - url: /checkout/3DS2-documentation
+      title: 3DS2 Documentation
   - title: Resources
     items:
     - url: /resources/

--- a/checkout/index.md
+++ b/checkout/index.md
@@ -12,6 +12,14 @@ sidebar:
       title: Payment
     - url: /checkout/after-payment
       title: After Payment
+  - title: Resources
+    items:
+    - url: /resources/
+      title: Introduction
+    - url: /resources/test-data
+      title: Test Data
+    - url: /resources/demoshop
+      title: Demoshop
 ---
 
 {% include alert.html type="warning"

--- a/checkout/payment.md
+++ b/checkout/payment.md
@@ -10,6 +10,8 @@ sidebar:
       title: Payment
     - url: /checkout/after-payment
       title: After Payment
+    - url: /checkout/3DS2-documentation
+      title: 3DS2 Documentation
   - title: Resources
     items:
     - url: /resources/

--- a/checkout/payment.md
+++ b/checkout/payment.md
@@ -10,6 +10,14 @@ sidebar:
       title: Payment
     - url: /checkout/after-payment
       title: After Payment
+  - title: Resources
+    items:
+    - url: /resources/
+      title: Introduction
+    - url: /resources/test-data
+      title: Test Data
+    - url: /resources/demoshop
+      title: Demoshop
 ---
 
 {% include alert.html type="warning"

--- a/resources/demoshop.md
+++ b/resources/demoshop.md
@@ -4,14 +4,6 @@ opengraph:
     description: Introduction to Swedbank Pay Resources
 sidebar:
   navigation:
-  - title: Checkout
-    items:
-    - url: /checkout/
-      title: Introduction
-    - url: /checkout/payment
-      title: Payment
-    - url: /checkout/after-payment
-      title: After Payment
   - title: Resources
     items:
     - url: /resources/

--- a/resources/demoshop.md
+++ b/resources/demoshop.md
@@ -1,7 +1,7 @@
 ---
-title: Swedbank Pay Developer Portal – Resources
+title: Swedbank Pay Resources – Introduction
 opengraph:
-    description: Swedbank Pay Developer Resources
+    description: Introduction to Swedbank Pay Resources
 sidebar:
   navigation:
   - title: Checkout
@@ -22,9 +22,14 @@ sidebar:
       title: Demoshop
 ---
 
+
 {% include alert.html type="warning"
                       icon="warning"
                       header="Site under development"
                       body="The Developer Portal is under construction and should not be used to integrate against Swedbank Pay's APIs yet." %}
 
-{% include jumbotron.html body="In this section you find various **resources** for Swedbank Pay's API Platform." %}
+
+{% include jumbotron.html body=
+"We are working on a brand new demoshop for you! 
+In the meantime, knock yourself out with our existing [demoshop](https://ecom.externalintegration.payex.com/pspdemoshop)" %}
+

--- a/resources/index.md
+++ b/resources/index.md
@@ -1,0 +1,22 @@
+---
+title: Swedbank Pay Developer Portal – Resources
+opengraph:
+    description: Swedbank Pay Developer Resources
+sidebar:
+  navigation:
+  - title: Resources
+    items:
+    - url: /checkout/
+      title: Introduction
+    - url: /checkout/payment
+      title: Payment
+    - url: /checkout/after-payment
+      title: After Payment
+---
+
+{% include alert.html type="warning"
+                      icon="warning"
+                      header="Site under development"
+                      body="The Developer Portal is under construction and should not be used to integrate against Swedbank Pay's APIs yet." %}
+
+{% include jumbotron.html body="In this section you find various **resources** for Swedbank Pay's API Platform." %}

--- a/resources/index.md
+++ b/resources/index.md
@@ -4,14 +4,6 @@ opengraph:
     description: Swedbank Pay Developer Resources
 sidebar:
   navigation:
-  - title: Checkout
-    items:
-    - url: /checkout/
-      title: Introduction
-    - url: /checkout/payment
-      title: Payment
-    - url: /checkout/after-payment
-      title: After Payment
   - title: Resources
     items:
     - url: /resources/

--- a/resources/test-data.md
+++ b/resources/test-data.md
@@ -4,14 +4,6 @@ opengraph:
     description: Introduction to Swedbank Pay Resources
 sidebar:
   navigation:
-  - title: Checkout
-    items:
-    - url: /checkout/
-      title: Introduction
-    - url: /checkout/payment
-      title: Payment
-    - url: /checkout/after-payment
-      title: After Payment
   - title: Resources
     items:
     - url: /resources/

--- a/resources/test-data.md
+++ b/resources/test-data.md
@@ -1,0 +1,240 @@
+---
+title: Swedbank Pay Resources – Introduction
+opengraph:
+    description: Introduction to Swedbank Pay Resources
+sidebar:
+  navigation:
+  - title: Checkout
+    items:
+    - url: /checkout/
+      title: Introduction
+    - url: /checkout/payment
+      title: Payment
+    - url: /checkout/after-payment
+      title: After Payment
+  - title: Resources
+    items:
+    - url: /resources/
+      title: Introduction
+    - url: /resources/test-data
+      title: Test Data
+    - url: /resources/demoshop
+      title: Demoshop
+---
+
+{% include alert.html type="warning"
+                      icon="warning"
+                      header="Site under development"
+                      body="The Developer Portal is under construction and should not be used to integrate against Swedbank Pay's APIs yet." %}
+
+{% include jumbotron.html body="Testing, are we? Good! Here's some data you can use to test and verify your integration!" %}
+
+## Swedbank Pay Checkout Test Data
+
+During a PayEx Checkout implementation you can use the test data related to the different payment methods listed below. To see PayEx Checkout in action, please visit our [demoshop](https://ecom.externalintegration.payex.com/pspdemoshop)
+
+To test a logged in user in the Demo Shop, please use the following test data:
+
+### Norway
+
+{:.table .table-striped}
+| Type      | Data     |  Description 
+|:----------------------|----------|:-------------|
+| `Email`               | `olivia.nyhuus@payex.com` | The e-mail address of the payer.
+| `Mobile number`       | `+47 98765432` | The mobile phone number of the payer. Format Norway: +4799999999.
+| `SSN`                 | `26026708248` | The social security number of the payer. Format: Norway DDMMYYXXXXX
+| `ZipCode`             | `1642` | The city zip code. Format: Norway XXXX
+
+### Sweden
+
+{:.table .table-striped}
+| Type              | Data       |  Description |
+|:------------------|:----------:|:-------------|
+| `Email`           | `leia.ahlstrom@payex.com` | The e-mail address of the payer.
+| `Mobile number`   | `+46 739000001` | The mobile phone number of the payer. Format Sweden: +46707777777. 
+| `SSN`             | `971020-2392` | The social security number of the payer. Sweden: YYYYMMDDXXXX.
+| `ZipCode`         | `19792` | The city zip code. Format: Sweden XXXXX
+
+
+## Credit Card Test Data
+
+### Visa
+
+{:.table .table-striped}
+| Card number   | Expiry       |  CVC | Type of test data
+|:-------|:----------:|:-------------|:---
+| `4925000000000004`| After the current month | Any | Loopback only
+| `4581097032723517`| After the current month | Any | Loopback only
+| `4581099940323133`| After the current month | Any | Loopback only
+| `5226600159865967`| After the current month | Any | Loopback only
+| `5226603115488031`| After the current month | Any | Loopback only
+| `5226604266737382`| After the current month | Any | Loopback only
+| `5226600156995650`| After the current month | Any | Loopback only
+
+### American Express
+
+{:.table .table-striped}
+| Card number              | Expiry       |  CVC | Type of test data
+|:------------------|:----------:|:-------------|:---
+| `377601000000000`           | After the current month | `525` | Amex & loopback
+
+### JCB
+
+{:.table .table-striped}
+| Card number              | Expiry       |  CVC |
+|:-------------------------|:----------:--|:-----|
+| `3569990010082211`       | After the current month | `123` |
+
+### Diners
+
+{:.table .table-striped}
+| Card number              | Expiry       |  CVC |
+|:-------------------------|:----------:--|:-----|
+| `6148201829798`       | After the current month | `832` |
+
+### Maestro
+
+{:.table .table-striped}
+| Card number              | Expiry       |  CVC | Type of test data
+|:-------------------------|:----------:--|:-----|:-------
+| `6764429999947470`       | 03/17        | `066` | Evry & loopback
+
+### Dankort
+
+{:.table .table-striped}
+| Card number              | Expiry       |  CVC | Type of test data
+|:-------------------------|:----------:--|:-----|:-------
+| `5019994016316467`       | 10/23        | `375` | NETS & loopback
+| `5019994001307083`       | 05/21        | `615` | NETS & loopback
+
+### Visa/DanKort
+
+{:.table .table-striped}
+| Card number              | Expiry       |  CVC | Type of test data
+|:-------------------------|:----------:--|:-----|:-------
+| `4571994016401817`       | 10/17        | `212` | NETS & loopback
+| `4571994016471869`       | 01/19        | `829` | NETS & loopback
+
+## Failure Testing
+
+For testing errors in transactions there are two different methods. The first method is performed through 3DSecure, and the second method is for testing errors thorugh spesific amounts.
+
+### 3DSecure Method
+
+First, POST a Payment (operation purchase) and enter the link to the payment page. Example URL: -
+<https://ecom.externalintegration.payex.com/creditcardv2/payments/authorize/739cbaeae33320a5b289e2fc135a8ae443e7b510474c2785683f71c497b49552> .
+Fill the data for either the Visa or MasterCard as shown below.
+
+{:.table .table-striped}
+| Card type                | Card number              | Expiry       |  CVC | Type of test data
+|:-------------------------|:----------:--|:-----|:-------|:---
+| Visa | `4761739001010416`       | 12/22        | `268` | 3DS enrolled, ECI 5, Evry & loopback
+| MasterCard | `5226612199533406`       | 09/28        | `602` | 3DS enrolled, ECI 6, Evry & loopback
+
+After pressing the purchase button you will then be taken to a menu where you can select Authentication status, menu is displayed in the picture under:
+
+<!--- REMEMBER TO ADD PICTURE HERE -->
+
+In this menu there is a few different options to choose from, choose the status you want to test. When selected, simply press the Continue button and the status you selected will be sent with the payment.
+
+### Amount Error Testing Method
+
+We have some preset amounts that can be used to produce error codes. When making a payment (operation purchase) enter one of these numbers from the list below, in the prices object ("amount": <    number>,) before submitting a transaction. Then the error message displayed behind the numbers will be sent with your payment in the test environment.
+
+The amounts that can be used and produce error codes (transactionThirdPartyError):
+
+{:.table .table-striped}
+| Number    | Error message
+|:----       |:------------
+|900313     |REJECTED_BY_ACQUIRER_INVALID_AMOUNT
+|900330     |REJECTED_BY_ACQUIRER_FORMAT_ERROR
+|900334     |REJECTED_BY_ACQUIRER_POSSIBLE_FRAUD
+|900343     |REJECTED_BY_ACQUIRER_CARD_STOLEN
+|900354     |REJECTED_BY_ACQUIRER_CARD_EXPIRED
+|900351     |REJECTED_BY_ACQUIRER_INSUFFICIENT_FUNDS
+|900359     |CARD_DECLINED
+|900362     |REJECTED_BY_PAYEX_CARD_BLACKLISTED
+|900391     |ACQUIRER_HOST_OFFLINE
+|9002xx (xx = 10 = ten seconds, example 900210)|ACQUIRER_TIMEOUT
+
+## Invoice Test Data
+
+### Norway
+
+{:.table .table-striped}
+| Type      | Data     |
+|:----------|----------|
+| SSN       | 26026708248 |
+| Name      | Olivia Nyhuus |
+| Adress    | SaltnesToppen 43 |
+| City      | 1642 Saltnes | 
+
+### Sweden
+
+{:.table .table-striped}
+| Type      | Data     | Alternative data
+|:----------|----------|:---
+| SSN       | 600307-1161	 | 971020-2392
+| Name      | Azra Oliveira	 | Leia Ahlstrom
+| Adress    | Helgestavägen 9 | Helgestavägen 9	
+| City      | 19792 Bro | 19792 Bro
+| msisdn    |           | +46739000001
+| email     |           | leia.ahlstrom@payex.com
+
+### Finland
+
+{:.table .table-striped}
+| Type      | Data     |
+|:----------|----------|
+| SSN       | 100584-451P |
+| Name      | Järvilehto Kimmo |
+| Adress    | Kiannonkatu 88 |
+| City      | 	90500 Oulu | 
+
+## Invoice Service Test Data
+Use any name, adress etc.
+
+## Vipps Test Data
+For testing a positive purchase (in our external integration test environment), please use any mobile number, except within the range: 99999991-99999999, as these will trigger error messages. The error messages are documented in the table below. There will be no user dialog at the mobile phone when testing Vipps.
+
+{:.table .table-striped}
+| Mobile number    | Error message
+|:----       |:------------
+|99999991     |Vipps internal error
+|99999992     |Request Validation error message on paticular request parameter
+|99999993     |Transaction Id already exists in vipps
+|99999994     |PSPID not enrolled in vipps
+|99999995     |Invalid payment model type
+|99999996     |User Vipps App version not supported
+|99999997     |User not Registered with Vipps
+|99999998     |Merchant not available or active
+
+Since there is no user dialog when testing Vipps in external integration, the following mobile numbers can be used to simulate consumer action/behaviour in Vipps application.
+
+{:.table .table-striped}
+| Mobile number      | Simulation     |
+|:----------|----------|
+| 99999990       | Timeout, i.e. the consumer does not confirm the payment in the Vipps app in time.|
+| 99999989      | Cancellation by consumer in app. |
+
+## Swish Test Data
+For testing a positive purchase (in our external integration test environment), please use any mobile number. E.g: +46 739000001
+
+To simulate an error message, set description in POST Create Payment or Create Payment Order to one of the following values:
+
+{:.table .table-striped}
+| Description      | Simulates     |
+|:----------|----------|
+| RF07      | Transaction declined |
+| TM01	    | Swish timed out before the payment was started |
+| BANKIDCL  | Payer cancelled BankId signing |
+
+## Callback Test Data
+
+{:.table .table-striped}
+| URL      | Response     |
+|:----------|----------|
+| https://api.internaltest.payex.com/psp/fakecallback      | 200 OK |
+| https://api.internaltest.payex.com/psp/fakecallback/notfound    | 404 Not Found |
+| https://api.internaltest.payex.com/psp/fakecallback/badrequest  | 400 Bad Request |
+| https://api.internaltest.payex.com/psp/fakecallback/random | 200 OK, 404 Not Found or 400 Bad Request at random |


### PR DESCRIPTION
3DS2 documentation is added to checkout as a subsection in this branch.

Notes:

1. Some tables are not adequate visually. The best example is the first two tables where the cell width differs. Tried some simple tricks to conform the tables, unfortunately without success. Maybe we can take a look at this?

2. In the description for the "payeeInfo.payeeReference" property, there is a link to the Technical Reference section at the old Developer Portal (https://developer.payex.com/xwiki/wiki/developer/view/Main/ecommerce/technical-reference/#HPayeeReference). Since we don't have the equivalent section at the new portal I haven't applied a link yet.

3. I noticed that Resource's menu is on the checkout pages. I believe this should be removed?