### PR TITLE
Feature/dx 488 invoice guids

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,3 +30,4 @@ defaults:
       paymentId: 7e6cdfc3-1276-44e9-9992-7cf4419750e1
       transactionId: ec2a9b09-601a-42ae-8e33-a5737e1cf177
       paymentOrderId: 09ccd29a-7c4f-4752-9396-12100cbfecce
+      merchantId: 5cabf558-5283-482f-b252-4d58e06f6f3b

--- a/_includes/authorizations-resource.md
+++ b/_includes/authorizations-resource.md
@@ -54,7 +54,7 @@ Content-Type: application/json
                     "operations": [
                         {
                             "method": "POST",
-                            "href": "https://api.stage.payex.com/psp/{{payment-instrument}}/payments/{{page.paymentId}}/authorizations",
+                            "href": "https://api.externalintegration.payex.com/psp/{{payment-instrument}}/payments/{{page.paymentId}}/authorizations",
                             "rel": "create-authorization",
                             "contentType": "application/json"
                         },

--- a/_includes/one-click-payments.md
+++ b/_includes/one-click-payments.md
@@ -44,16 +44,16 @@ provided below.
 **Request Towards Authorizations Resource**
 
 ```http
-GET https://api.payex.com/psp/creditcard/payments/<payment-id>/<authorizations> HTTP/1.1
-Host: api.payex.com
+GET /psp/creditcard/payments/<payment-id>/<authorizations> HTTP/1.1
+Host: api.externalintegration.payex.com
 ```
 
 {:.code-header}
 **Request Towards Verifications Resource**
 
 ```http
-GET https://api.payex.com/psp/creditcard/payments/<payment-id>/<verifications> HTTP/1.1
-Host: api.payex.com
+GET /psp/creditcard/payments/<payment-id>/<verifications> HTTP/1.1
+Host: api.externalintegration.payex.com
 ```
 
 You need to store the `paymentToken` from the response in your system and keep

--- a/_includes/operations-reference.md
+++ b/_includes/operations-reference.md
@@ -102,7 +102,7 @@ JavaScript or server-side in HTML as shown below.
     </head>
     <body>
         <div id="checkout"></div>
-        <script src="https://ecom.payex.com/paymentmenu/core/scripts/client/px.paymentmenu.client.js?token=38540e86bd78e885fba2ef054ef9792512b1c9c5975cbd6fd450ef9aa15b1844&culture=nb-NO"></script>
+        <script src="https://ecom.externalintegration.payex.com/paymentmenu/core/scripts/client/px.paymentmenu.client.js?token=38540e86bd78e885fba2ef054ef9792512b1c9c5975cbd6fd450ef9aa15b1844&culture=nb-NO"></script>
         <script language="javascript">
             payex.hostedView.paymentMenu({
                 container: 'checkout',

--- a/_includes/payment-resource.md
+++ b/_includes/payment-resource.md
@@ -10,7 +10,7 @@ possible to perform in the current state of the payment.
 
 ```http
 GET /psp/{{payment-instrument}}/payments/{{ page.paymentId }}/ HTTP/1.1
-Host: api.payex.com
+Host: api.externalintegration.payex.com
 Authorization: Bearer <AccessToken>
 Content-Type: application/json
 ```

--- a/_includes/purchase.md
+++ b/_includes/purchase.md
@@ -23,11 +23,11 @@ Content-Type: application/json
         "userAgent": "Mozilla/5.0...",
         "language": "sv-SE",
         "urls": {
-            "completeUrl": "http://test-dummy.net/payment-completed",
-            "cancelUrl": "http://test-dummy.net/payment-canceled",
-            "callbackUrl": "http://test-dummy.net/payment-callback",
-            "logoUrl": "http://test-dummy.net/payment-logo.png",
-            "termsOfServiceUrl": "http://test-dummy.net/payment-terms.pdf",
+            "completeUrl": "http://example.com/payment-completed",
+            "cancelUrl": "http://example.com/payment-canceled",
+            "callbackUrl": "http://example.com/payment-callback",
+            "logoUrl": "http://example.com/payment-logo.png",
+            "termsOfServiceUrl": "http://example.com/payment-terms.pdf",
         },
         "payeeInfo": {
             "payeeId": "12345678-1234-1234-1234-123456789012",

--- a/_includes/purchase.md
+++ b/_includes/purchase.md
@@ -163,13 +163,13 @@ Content-Type: application/json
   },
   "operations": [
     {
-      "href": "https://api.payex.com/psp/creditcard/payments/{{ page.paymentId }}",
+      "href": "https://api.externalintegration.payex.com/psp/creditcard/payments/{{ page.paymentId }}",
       "rel": "update-payment-abort",
       "method": "PATCH",
       "contentType": "application/json"
     },
     {
-      "href": "https://ecom.payex.com/creditcard/payments/authorize/123456123412341234123456789012",
+      "href": "https://ecom.externalintegration.payex.com/creditcard/payments/authorize/123456123412341234123456789012",
       "rel": "redirect-authorization",
       "method": "GET",
       "contentType": "text/html"

--- a/_includes/recurring-card-payments.md
+++ b/_includes/recurring-card-payments.md
@@ -188,7 +188,7 @@ Content-Type: application/json
             "contentType": "application/json"
         },
         {
-            "href": "https://ecom.payex.com/creditcard/payments/verification/123456123412341234123456789012",
+            "href": "https://ecom.externalintegration.payex.com/creditcard/payments/verification/123456123412341234123456789012",
             "rel": "redirect-verification",
             "method": "GET",
             "contentType": "application/json"

--- a/checkout/checkin.md
+++ b/checkout/checkin.md
@@ -104,7 +104,7 @@ Content-Type: application/json
         {
             "method": "GET",
             "rel": "redirect-consumer-identification",
-            "href": "https://ecom.stage.payex.com/consumers/sessions/7e380fbb3196ea76cc45814c1d99d59b66db918ce2131b61f585645eff364871",
+            "href": "https://ecom.externalintegration.payex.com/consumers/sessions/7e380fbb3196ea76cc45814c1d99d59b66db918ce2131b61f585645eff364871",
             "contentType": "text/html"
         },
         {

--- a/checkout/other-features.md
+++ b/checkout/other-features.md
@@ -1332,7 +1332,7 @@ The structure of a problem message will look like this:
 
 ```js
 {
-    "type": "https://api.payex.com/psp/creditcard/inputerror",
+    "type": "https://api.payex.com/psp/errordetail/creditcard/inputerror",
     "title": "There was an input error",
     "detail": "Please correct the errors and retry the request",
     "instance": "9a20d737-670d-42bf-9a9a-d36736de8721",
@@ -1361,7 +1361,7 @@ The structure of a problem message will look like this:
 ### Common Problems
 
 All common problem types will have a URI in the format
-`https://api.payex.com/psp/<error-type>`.
+`https://api.payex.com/psp/errordetail/<payment-instrument>/<error-type>`.
 The **URI is an identifier** and is currently not possible to dereference,
 although that might be possible in the future.
 

--- a/checkout/other-features.md
+++ b/checkout/other-features.md
@@ -399,7 +399,7 @@ The `view-paymentorder` operation contains the URI of the JavaScript that needs 
     </head>
     <body>
         <div id="checkout"></div>
-        <script src="https://ecom.payex.com/paymentmenu/core/scripts/client/px.paymentmenu.client.js?token=38540e86bd78e885fba2ef054ef9792512b1c9c5975cbd6fd450ef9aa15b1844&culture=nb-NO"></script>
+        <script src="https://ecom.externalintegration.payex.com/paymentmenu/core/scripts/client/px.paymentmenu.client.js?token=38540e86bd78e885fba2ef054ef9792512b1c9c5975cbd6fd450ef9aa15b1844&culture=nb-NO"></script>
         <script language="javascript">
             payex.hostedView.paymentMenu({
                 container: 'checkout',
@@ -1332,7 +1332,7 @@ The structure of a problem message will look like this:
 
 ```js
 {
-    "type": "https://api.payex.com/psp/<error_type>",
+    "type": "https://api.payex.com/psp/creditcard/inputerror",
     "title": "There was an input error",
     "detail": "Please correct the errors and retry the request",
     "instance": "9a20d737-670d-42bf-9a9a-d36736de8721",

--- a/checkout/other-features.md
+++ b/checkout/other-features.md
@@ -219,7 +219,7 @@ Content-Type: application/json
     "paymentorder": "/psp/payments/{{ page.paymentOrderId }}",
     "urls": {
         "id": "/psp/payments/{{ page.paymentOrderId }}/urls",
-        "hostUrls": [ "https://example.com", "http://test-dummy2.net" ],
+        "hostUrls": [ "https://example.com", "http://example.net" ],
         "completeUrl": "http://example.com/payment-complete",
         "cancelUrl": "http://example.com/payment-canceled",
         "paymentUrl": "http://example.com/perform-payment",

--- a/index.md
+++ b/index.md
@@ -270,7 +270,7 @@ The structure of a problem message will look like this:
 
 ```js
 {
-    "type": "https://api.payex.com/psp/creditcard/inputerror",
+    "type": "https://api.payex.com/psp/errordetail/creditcard/inputerror",
     "title": "There was an input error",
     "detail": "Please correct the errors and retry the request",
     "instance": "9a20d737-670d-42bf-9a9a-d36736de8721",
@@ -299,9 +299,10 @@ The structure of a problem message will look like this:
 ### Common Problems
 
 All common problem types will have a URI in the format
-`https://api.payex.com/psp/<error-type>`. The **URI is an identifier** that you
-can hard-code and implement logic around. It is currently not not possible to
-dereference this URI, although that might be possible in the future.
+`https://api.payex.com/psp/errordetail/<payment-instrument>/<error-type>`. The
+**URI is an identifier** that you can hard-code and implement logic around. It
+is currently not not possible to dereference this URI, although that might be
+possible in the future.
 
 {:.table .table-striped}
 | Type                 | Status | Description                                                                                                                                        |
@@ -315,8 +316,8 @@ dereference this URI, although that might be possible in the future.
 ### Payment Instrument Specific Problems
 
 Problem types for a specific payment instrument will have a URI in the format
-`https://api.payex.com/psp/<payment-instrument>/<error-type>`. You can read
-more about the payment instrument specific problem messages below:
+`https://api.payex.com/psp/errordetail/<payment-instrument>/<error-type>`. You
+can read more about the payment instrument specific problem messages below:
 
 * [Card Payments][card-problems]
 * [Invoice Payments][invoice-problems]

--- a/index.md
+++ b/index.md
@@ -270,7 +270,7 @@ The structure of a problem message will look like this:
 
 ```js
 {
-    "type": "https://api.payex.com/psp/inputerror",
+    "type": "https://api.payex.com/psp/creditcard/inputerror",
     "title": "There was an input error",
     "detail": "Please correct the errors and retry the request",
     "instance": "9a20d737-670d-42bf-9a9a-d36736de8721",

--- a/payments/card/other-features.md
+++ b/payments/card/other-features.md
@@ -338,7 +338,7 @@ Content-Type: application/json
             "contentType": "application/json"
         },
         {
-            "href": "https://ecom.payex.com/creditcard/payments/authorize/123456123412341234123456789012",
+            "href": "https://ecom.externalintegration.payex.com/creditcard/payments/authorize/123456123412341234123456789012",
             "rel": "redirect-authorization",
             "method": "GET",
             "contentType": "text/html"
@@ -641,7 +641,7 @@ Content-Type: application/json
             "contentType": "application/json"
         },
         {
-            "href": "https://ecom.payex.com/creditcard/payments/verification/123456123412341234123456789012",
+            "href": "https://ecom.externalintegration.payex.com/creditcard/payments/verification/123456123412341234123456789012",
             "rel": "redirect-verification",
             "method": "GET",
             "contentType": "application/json"
@@ -821,7 +821,7 @@ All contract types will have the following URI in front of type:
 ### Acquirer and 3-D Secure Problem Types
 
 All acquirer error types will have the following URI in front of type:
-`https://api.payex.com/psp/errordetail/creditcard/<errorType>`
+`https://api.externalintegration.payex.com/psp/errordetail/creditcard/<errorType>`
 
 {:.table .table-striped}
 | Type                           | Status | Description                                                                                   |

--- a/payments/card/other-features.md
+++ b/payments/card/other-features.md
@@ -821,7 +821,7 @@ All contract types will have the following URI in front of type:
 ### Acquirer and 3-D Secure Problem Types
 
 All acquirer error types will have the following URI in front of type:
-`https://api.externalintegration.payex.com/psp/errordetail/creditcard/<errorType>`
+`https://api.payex.com/psp/errordetail/creditcard/<error-type>`
 
 {:.table .table-striped}
 | Type                           | Status | Description                                                                                   |

--- a/payments/card/seamless-view.md
+++ b/payments/card/seamless-view.md
@@ -309,13 +309,13 @@ Content-Type: application/json
     },
     "operations": [
       {
-        "href": "https://api.payex.com/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "href": "https://api.externalintegration.payex.com/psp/creditcard/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
         "rel": "update-payment-abort",
         "method": "PATCH",
         "contentType": "application/json"
       },
       {
-        "href": "https://ecom.payex.com/creditcard/payments/authorize/123456123412341234123456789012",
+        "href": "https://ecom.externalintegration.payex.com/creditcard/payments/authorize/123456123412341234123456789012",
         "rel": "redirect-authorization",
         "method": "GET",
         "contentType": "text/html"

--- a/payments/credit-account/other-features.md
+++ b/payments/credit-account/other-features.md
@@ -38,7 +38,7 @@ help narrow down the specifics of the problem.
 ## Error types from Swedbank Pay Invoice and third parties
 
 All invoice error types will have the following URI in front of type:
-`https://api.payex.com/psp/errordetail/invoice/<errorType>`
+`https://api.externalintegration.payex.com/psp/errordetail/invoice/<errorType>`
 
 {:.table .table-striped}
 | Type            | Status | Description                   |

--- a/payments/credit-account/other-features.md
+++ b/payments/credit-account/other-features.md
@@ -38,7 +38,7 @@ help narrow down the specifics of the problem.
 ## Error types from Swedbank Pay Invoice and third parties
 
 All invoice error types will have the following URI in front of type:
-`https://api.externalintegration.payex.com/psp/errordetail/invoice/<errorType>`
+`https://api.payex.com/psp/errordetail/invoice/<error-type>`
 
 {:.table .table-striped}
 | Type            | Status | Description                   |

--- a/payments/invoice/after-payment.md
+++ b/payments/invoice/after-payment.md
@@ -120,14 +120,14 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-    "payment": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "payment": "/psp/invoice/payments/{{ page.paymentId }}",
     "capture": {
         "itemDescriptions": {
-            "id": "/psp/invoice/payments/<captureId>/transactions/12345678-1234-1234-1234-123456789012/itemDescriptions"
+            "id": "/psp/invoice/payments/<captureId>/transactions/{{ page.transactionId }}/itemDescriptions"
         },
-        "invoiceCopy": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/captures/12345678-1234-1234-1234-123456789012/invoicecopy",
+        "invoiceCopy": "/psp/invoice/payments/{{ page.paymentId }}/captures/{{ page.transactionId }}/invoicecopy",
         "transaction": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions/12345678-1234-1234-1234-123456789012",
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/transactions/{{ page.transactionId }}",
             "created": "2016-09-14T01:01:01.01Z",
             "updated": "2016-09-14T01:01:01.03Z",
             "type": "Capture",
@@ -162,7 +162,7 @@ specific invoice payment.
 **Request**
 
 ```http
-GET /psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/captures HTTP/1.1
+GET /psp/invoice/payments/{{ page.paymentId }}/captures HTTP/1.1
 Host: api.externalintegration.payex.com
 Authorization: Bearer <AccessToken>
 Content-Type: application/json
@@ -176,14 +176,14 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-    "payment": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "payment": "/psp/invoice/payments/{{ page.paymentId }}",
     "captures": [{
         "itemDescriptions": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions/5adc265f-f87f-4313-577e-08d3dca1a26c/itemdescriptions"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/transactions/{{ page.paymentId }}/itemdescriptions"
         },
-        "invoiceCopy": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/captures/5adc265f-f87f-4313-577e-08d3dca1a26c/invoicecopy",
+        "invoiceCopy": "/psp/invoice/payments/{{ page.paymentId }}/captures/{{ page.paymentId }}/invoicecopy",
         "transaction": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions/5adc265f-f87f-4313-577e-08d3dca1a26c",
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/transactions/{{ page.paymentId }}",
             "created": "2016-09-14T01:01:01.01Z",
             "updated": "2016-09-14T01:01:01.03Z",
             "type": "Capture",
@@ -230,7 +230,7 @@ or partially captured invoice payment.
 ***Request***
 
 ```http
-POST /psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/cancellations HTTP/1.1
+POST /psp/invoice/payments/{{ page.paymentId }}/cancellations HTTP/1.1
 Host: api.externalintegration.payex.com
 Authorization: Bearer <AccessToken>
 Content-Type: application/json
@@ -259,10 +259,10 @@ newly created `cancel` transaction.
 
 ```http
 {
-    "payment": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "payment": "/psp/invoice/payments/{{ page.paymentId }}",
     "cancellation": {
         "transaction": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions/12345678-1234-1234-1234-123456789012",
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/transactions/{{ page.transactionId }}",
             "created": "2016-09-14T01:01:01.01Z",
             "updated": "2016-09-14T01:01:01.03Z",
             "type": "Cancellation",
@@ -297,7 +297,7 @@ specific payment.
 
 ```http
 Request
-GET /psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/cancellations HTTP/1.1
+GET /psp/invoice/payments/{{ page.paymentId }}/cancellations HTTP/1.1
 Host: api.externalintegration.payex.com
 Authorization: Bearer <AccessToken>
 Content-Type: application/json
@@ -311,10 +311,10 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-    "payment": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "payment": "/psp/invoice/payments/{{ page.paymentId }}",
     "cancellations": [{
         "transaction": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions/5adc265f-f87f-4313-577e-08d3dca1a26c",
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/transactions/{{ page.paymentId }}",
             "created": "2016-09-14T01:01:01.01Z",
             "updated": "2016-09-14T01:01:01.03Z",
             "type": "Cancellation",
@@ -369,7 +369,7 @@ follows:
 **Request**
 
 ```http
-POST /psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/reversals HTTP/1.1
+POST /psp/invoice/payments/{{ page.paymentId }}/reversals HTTP/1.1
 Host: api.externalintegration.payex.com
 Authorization: Bearer <AccessToken>
 Content-Type: application/json
@@ -407,10 +407,10 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-    "payment": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "payment": "/psp/invoice/payments/{{ page.paymentId }}",
     "reversal": {
         "transaction": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions/12345678-1234-1234-1234-123456789012",
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/transactions/{{ page.transactionId }}",
             "created": "2016-09-14T01:01:01.01Z",
             "updated": "2016-09-14T01:01:01.03Z",
             "type": "Reversal",
@@ -444,7 +444,7 @@ The `reversals` resource will list the reversal transactions
 ***Request***
 
 ```http
-GET /psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/reversals HTTP/1.1
+GET /psp/invoice/payments/{{ page.paymentId }}/reversals HTTP/1.1
 Host: api.externalintegration.payex.com
 Authorization: Bearer <AccessToken>
 Content-Type: application/json
@@ -458,10 +458,10 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-    "payment": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "payment": "/psp/invoice/payments/{{ page.paymentId }}",
     "reversal": [{
         "transaction": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions/12345678-1234-1234-1234-123456789012",
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/transactions/{{ page.transactionId }}",
             "created": "2016-09-14T01:01:01.01Z",
             "updated": "2016-09-14T01:01:01.03Z",
             "type": "Reversal",

--- a/payments/invoice/direct.md
+++ b/payments/invoice/direct.md
@@ -182,14 +182,14 @@ Content-Type: application/json
         "userAgent": "Mozilla/5.0...",
         "language": "sv-SE",
         "urls": {
-            "completeUrl": "http://test-dummy.net/payment-completed",
-            "cancelUrl": "http://test-dummy.net/payment-canceled",
-            "callbackUrl": "http://test-dummy.net/payment-callback",
-            "logoUrl": "http://fakeservices.psp.dev.utvnet.net/logo.png",
-            "termsOfServiceUrl": "http://fakeservices.psp.dev.utvnet.net/terms.pdf"
+            "completeUrl": "http://example.com/payment-completed",
+            "cancelUrl": "http://example.com/payment-canceled",
+            "callbackUrl": "http://example.com/payment-callback",
+            "logoUrl": "http://example.com/logo.png",
+            "termsOfServiceUrl": "http://example.com/terms.pdf"
         },
         "payeeInfo": {
-            "payeeId": "12345678-1234-1234-1234-123456789012",
+            "payeeId": "{{ page.merchantId }}",
             "payeeReference": "PR123",
             "payeeName": "Merchant1",
             "productCategory": "PC1234",
@@ -267,7 +267,7 @@ Content-Type: application/json
 
 {
     "payment": {
-        "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "id": "/psp/invoice/payments/{{ page.paymentId }}",
         "number": 1234567890,
         "instrument": "Invoice",
         "created": "YYYY-MM-DDThh:mm:ssZ",
@@ -284,52 +284,52 @@ Content-Type: application/json
         "userAgent": "Mozilla/5.0...",
         "language": "sv-SE",
         "prices": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/prices"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/prices"
         },
         "transactions": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/transactions"
         },
         "authorizations": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/authorizations"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/authorizations"
         },
         "captures": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/captures"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/captures"
         },
         "reversals": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/reversals"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/reversals"
         },
         "cancellations": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/cancellations"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/cancellations"
         },
         "payeeInfo": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/payeeInfo"
         },
         "urls": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/urls"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/urls"
         },
         "settings": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/settings"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/settings"
         },
         "approvedLegalAddress": {
-            "id": "/psp/invoice/payments/<paymentId>/approvedlegaladdress"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress"
         },
         "maskedApprovedLegalAddress": {
-            "id": "/psp/invoice/payments/<paymentId>/maskedapprovedlegaladdress"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/maskedapprovedlegaladdress"
         }
     },
     "operations": [
         {
-            "href": "https://api.payex.com/psp/invoice/payments/<paymentId>",
+            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}",
             "rel": "update-payment-abort",
             "method": "PATCH"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/<paymentId>/authorizations",
+            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/authorizations",
             "rel": "create-authorize",
             "method": "POST"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/<paymentId>/approvedlegaladdress",
+            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
             "rel": "create-approved-legal-address",
             "method": "POST"
         }
@@ -348,7 +348,7 @@ possible to perform in the current state of the payment.
 **Request**
 
 ```http
-GET /psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/ HTTP/1.1
+GET /psp/invoice/payments/{{ page.paymentId }}/ HTTP/1.1
 Host: api.payex.com
 Authorization: Bearer <AccessToken>
 Content-Type: application/json
@@ -363,7 +363,7 @@ Content-Type: application/json
 
 {
     "payment": {
-        "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "id": "/psp/invoice/payments/{{ page.paymentId }}",
         "number": 1234567890,
         "created": "2016-09-14T13:21:29.3182115Z",
         "updated": "2016-09-14T13:21:57.6627579Z",
@@ -381,55 +381,55 @@ Content-Type: application/json
         "userAgent": "Mozilla/5.0...",
         "language": "sv-SE",
         "prices": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/prices"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/prices"
         },
         "transactions": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/transactions"
         },
         "authorizations": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/authorizations"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/authorizations"
         },
         "captures": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/captures"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/captures"
         },
         "reversals": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/reversals"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/reversals"
         },
         "cancellations": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/cancellations"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/cancellations"
         },
         "payeeInfo": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/payeeInfo"
         },
         "urls": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/urls"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/urls"
         },
         "settings": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/settings"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/settings"
         },
         "approvedLegalAddress": {
-            "id": "/psp/invoice/payments/<paymentId>/approvedlegaladdress"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress"
         },
         "maskedApprovedLegalAddress": {
-            "id": "/psp/invoice/payments/<paymentId>/maskedapprovedlegaladdress"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/maskedapprovedlegaladdress"
         }
     },
     "approvedLegalAddress": {
-        "id": "/psp/invoice/payments/<paymentId>/approvedlegaladdress"
+        "id": "/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress"
     },
     "operations": [
         {
-            "href": "https://api.payex.com/psp/invoice/payments/<paymentId>/captures",
+            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/captures",
             "rel": "create-capture",
             "method": "POST"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/<paymentId>/cancellations",
+            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/cancellations",
             "rel": "create-cancel",
             "method": "POST"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/<paymentId>/approvedlegaladdress",
+            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
             "rel": "create-approved-legal-address",
             "method": "POST"
         }

--- a/payments/invoice/direct.md
+++ b/payments/invoice/direct.md
@@ -319,17 +319,17 @@ Content-Type: application/json
     },
     "operations": [
         {
-            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}",
             "rel": "update-payment-abort",
             "method": "PATCH"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/authorizations",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}/authorizations",
             "rel": "create-authorize",
             "method": "POST"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
             "rel": "create-approved-legal-address",
             "method": "POST"
         }
@@ -349,7 +349,7 @@ possible to perform in the current state of the payment.
 
 ```http
 GET /psp/invoice/payments/{{ page.paymentId }}/ HTTP/1.1
-Host: api.payex.com
+Host: api.externalintegration.payex.com
 Authorization: Bearer <AccessToken>
 Content-Type: application/json
 ```
@@ -419,17 +419,17 @@ Content-Type: application/json
     },
     "operations": [
         {
-            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/captures",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}/captures",
             "rel": "create-capture",
             "method": "POST"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/cancellations",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}/cancellations",
             "rel": "create-cancel",
             "method": "POST"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
             "rel": "create-approved-legal-address",
             "method": "POST"
         }

--- a/payments/invoice/direct.md
+++ b/payments/invoice/direct.md
@@ -446,22 +446,22 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-    "href": "https://merchant/cancelUrl",
+    "href": "https://example.com/cancelUrl",
     "rel": "redirect-merchant-cancel",
     "method": "GET"
 }
 {
-    "href": "https://merchant/completeUrl",
+    "href": "https://example.com/completeUrl",
     "rel": "redirect-merchant-complete",
     "method": "GET"
 }
 {
-    "href": "https://merchant/cancelUrl",
+    "href": "https://example.com/cancelUrl",
     "rel": "redirect-merchant-cancel",
     "method": "GET"
 }
 {
-    "href": "https://merchant/completeUrl",
+    "href": "https://example.com/completeUrl",
     "rel": "redirect-merchant-complete",
     "method": "GET"
 }

--- a/payments/invoice/other-features.md
+++ b/payments/invoice/other-features.md
@@ -557,7 +557,7 @@ often help narrow down the specifics of the problem.
 ### Error types from Swedbank Pay Invoice and third parties
 
 All invoice error types will have the following URI in front of type:
-`https://api.externalintegration.payex.com/psp/errordetail/invoice/<errorType>`
+`https://api.payex.com/psp/errordetail/invoice/<error-type>`
 
 {:.table .table-striped}
 | Type            | Status | Description                   |

--- a/payments/invoice/other-features.md
+++ b/payments/invoice/other-features.md
@@ -499,7 +499,7 @@ Content-Type: application/json
             },
             "operations": [
                 {
-                    "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}",
+                    "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}",
                     "rel": "edit-authorization",
                     "method": "PATCH"
                 }
@@ -557,7 +557,7 @@ often help narrow down the specifics of the problem.
 ### Error types from Swedbank Pay Invoice and third parties
 
 All invoice error types will have the following URI in front of type:
-`https://api.payex.com/psp/errordetail/invoice/<errorType>`
+`https://api.externalintegration.payex.com/psp/errordetail/invoice/<errorType>`
 
 {:.table .table-striped}
 | Type            | Status | Description                   |

--- a/payments/invoice/other-features.md
+++ b/payments/invoice/other-features.md
@@ -117,14 +117,14 @@ Content-Type: application/json
         "userAgent": "Mozilla/5.0...",
         "language": "nb-NO",
         "urls": {
-            "completeUrl": "http://test-dummy.net/payment-completed",
-            "cancelUrl": "http://test-dummy.net/payment-canceled",
-            "callbackUrl": "http://test-dummy.net/payment-callback",
-            "logoUrl": "http://fakeservices.psp.dev.utvnet.net/logo.png",
-            "termsOfServiceUrl": "http://fakeservices.psp.dev.utvnet.net/terms.pdf"
+            "completeUrl": "http://example.com/payment-completed",
+            "cancelUrl": "http://example.com/payment-canceled",
+            "callbackUrl": "http://example.com/payment-callback",
+            "logoUrl": "http://example.com/logo.png",
+            "termsOfServiceUrl": "http://fexample.com/terms.pdf"
         },
         "payeeInfo": {
-            "payeeId": "12345678-1234-1234-1234-123456789012",
+            "payeeId": "{{ page.merchantId }}",
             "payeeReference": "PR123",
             "payeeName": "Merchant1",
             "productCategory": "PC1234",
@@ -150,11 +150,12 @@ POST /psp/invoice/payments HTTP/1.1
 Host: api.externalintegration.payex.com
 Authorization: Bearer <AccessToken>
 Content-Type: application/json
+
 {
     "payment": {
         "operation": "Recur",
         "intent": "Authorization",
-        "recurrenceToken": "5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "recurrenceToken": "{{ page.paymentId }}",
         "currency": "NOK",
         "amount": 1500,
         "vatAmount": 0,
@@ -165,7 +166,7 @@ Content-Type: application/json
             "callbackUrl": "https://example.com/payment-callback"
         },
         "payeeInfo": {
-            "payeeId": "12345678-1234-1234-1234-123456789012",
+            "payeeId": "{{ page.merchantId }}",
             "payeeReference": "CD1234",
             "payeeName": "Merchant1",
             "productCategory": "A123",
@@ -236,6 +237,7 @@ POST /psp/invoice/payments HTTP/1.1
 Host: api.externalintegration.payex.com
 Authorization: Bearer <AccessToken>
 Content-Type: application/json
+
 {
     "payment": {
         "operation": "Verify",
@@ -257,7 +259,7 @@ Content-Type: application/json
             "termsOfServiceUrl": "https://example.com/payment-terms.html"
         },
         "payeeInfo": {
-            "payeeId": "12345678-1234-1234-1234-123456789012",
+            "payeeId": "{{ page.merchantId }}",
             "payeeReference": "CD1234",
             "payeeName": "Merchant1",
             "productCategory": "A123",
@@ -279,7 +281,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 {
     "payment": {
-        "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "id": "/psp/invoice/payments/{{ page.paymentId }}",
         "number": 1234567890,
         "created": "2016-09-14T13:21:29.3182115Z",
         "updated": "2016-09-14T13:21:57.6627579Z",
@@ -293,37 +295,37 @@ Content-Type: application/json
         "userAgent": "Mozilla/5.0",
         "language": "nb-NO",
         "transactions": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/transactions"
         },
         "verifications": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/verifications"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/verifications"
         },
         "urls": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/urls"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/urls"
         },
         "payeeInfo": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/payeeInfo"
         },
         "settings": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/settings"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/settings"
         }
     },
     "operations": [
         {
             "method": "POST",
-            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/approvedlegaladdress",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
             "rel": "create-approved-legal-address",
             "contentType": "application/json"
         },
         {
             "method": "POST",
-            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/authorizations",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}/authorizations",
             "rel": "create-authorization",
             "contentType": "application/json"
         },
         {
             "method": "PATCH",
-            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}",
             "rel": "update-payment-abort",
             "contentType": "application/json"
         },
@@ -401,7 +403,7 @@ Swedbank Pay Payments where the payment is authorized.
 **Request**
 
 ```http
-POST /psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/authorizations HTTP/1.1
+POST /psp/invoice/payments/{{ page.paymentId }}/authorizations HTTP/1.1
 Host: api.externalintegration.payex.com
 Authorization: Bearer <AccessToken>
 Content-Type: application/json
@@ -464,20 +466,20 @@ Content-Type: application/json
 
 ```json
 {
-    "payment": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+    "payment": "/psp/invoice/payments/{{ page.paymentId }}",
     "authorization": {
-        "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/authorizations/12345678-1234-1234-1234-123456789012",
+        "id": "/psp/invoice/payments/{{ page.paymentId }}/authorizations/{{ page.transactionId }}",
         "consumer": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/consumer"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/consumer"
         },
         "legalAddress": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/legaladdress"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/legaladdress"
         },
         "billingAddress": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/billingaddress"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/billingaddress"
         },
         "transaction": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions/12345678-1234-1234-1234-123456789012",
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/transactions/{{ page.transactionId }}",
             "created": "2016-09-14T01:01:01.01Z",
             "updated": "2016-09-14T01:01:01.03Z",
             "type": "Authorization",
@@ -493,11 +495,11 @@ Content-Type: application/json
             "failedErrorDescription": "ThirdPartyErrorMessage",
             "isOperational": "TRUE",
             "activities": {
-                "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions/12345678-1234-1234-1234-123456789012/activities"
+                "id": "/psp/invoice/payments/{{ page.paymentId }}/transactions/{{ page.transactionId }}/activities"
             },
             "operations": [
                 {
-                    "href": "https://api.payex.com/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+                    "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}",
                     "rel": "edit-authorization",
                     "method": "PATCH"
                 }

--- a/payments/invoice/redirect.md
+++ b/payments/invoice/redirect.md
@@ -132,14 +132,14 @@ Content-Type: application/json
         "userAgent": "Mozilla/5.0...",
         "language": "sv-SE",
         "urls": {
-            "completeUrl": "http://test-dummy.net/payment-completed",
-            "cancelUrl": "http://test-dummy.net/payment-canceled",
-            "callbackUrl": "http://test-dummy.net/payment-callback",
-            "logoUrl": "http://fakeservices.psp.dev.utvnet.net/logo.png",
-            "termsOfServiceUrl": "http://fakeservices.psp.dev.utvnet.net/terms.pdf"
+            "completeUrl": "http://example.com/payment-completed",
+            "cancelUrl": "http://example.com/payment-canceled",
+            "callbackUrl": "http://example.com/payment-callback",
+            "logoUrl": "http://example.com/logo.png",
+            "termsOfServiceUrl": "http://example.com/terms.pdf"
         },
         "payeeInfo": {
-            "payeeId": "12345678-1234-1234-1234-123456789012",
+            "payeeId": "{{ page.merchantId }}",
             "payeeReference": "PR123",
             "payeeName": "Merchant1",
             "productCategory": "PC1234",
@@ -217,7 +217,7 @@ Content-Type: application/json
 
 {
     "payment": {
-        "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "id": "/psp/invoice/payments/{{ page.paymentId }}",
         "number": 1234567890,
         "instrument": "Invoice",
         "created": "2016-09-14T13:21:29.3182115Z",
@@ -234,52 +234,52 @@ Content-Type: application/json
         "userAgent": "Mozilla/5.0...",
         "language": "sv-SE",
         "prices": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/prices"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/prices"
         },
         "transactions": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/transactions"
         },
         "authorizations": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/authorizations"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/authorizations"
         },
         "captures": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/captures"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/captures"
         },
         "reversals": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/reversals"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/reversals"
         },
         "cancellations": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/cancellations"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/cancellations"
         },
         "payeeInfo": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/payeeInfo"
         },
         "urls": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/urls"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/urls"
         },
         "settings": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/settings"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/settings"
         },
         "approvedLegalAddress": {
-            "id": "/psp/invoice/payments/<paymentId>/approvedlegaladdress"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress"
         },
         "maskedApprovedLegalAddress": {
-            "id": "/psp/invoice/payments/<paymentId>/maskedapprovedlegaladdress"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/maskedapprovedlegaladdress"
         }
     },
     "operations": [
         {
-            "href": "https://api.payex.com/psp/invoice/payments/<paymentId>",
+            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}",
             "rel": "update-payment-abort",
             "method": "PATCH"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/<paymentId>/authorizations",
+            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/authorizations",
             "rel": "create-authorize",
             "method": "POST"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/<paymentId>/approvedlegaladdress",
+            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
             "rel": "create-approved-legal-address",
             "method": "POST"
         }
@@ -298,7 +298,7 @@ possible to perform in the current state of the payment.
 **Request**
 
 ```http
-GET /psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/ HTTP/1.1
+GET /psp/invoice/payments/{{ page.paymentId }}/ HTTP/1.1
 Host: api.payex.com
 Authorization: Bearer <AccessToken>
 Content-Type: application/json
@@ -313,7 +313,7 @@ Content-Type: application/json
 
 {
     "payment": {
-        "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "id": "/psp/invoice/payments/{{ page.paymentId }}",
         "number": 1234567890,
         "created": "2016-09-14T13:21:29.3182115Z",
         "updated": "2016-09-14T13:21:57.6627579Z",
@@ -331,55 +331,55 @@ Content-Type: application/json
         "userAgent": "Mozilla/5.0...",
         "language": "sv-SE",
         "prices": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/prices"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/prices"
         },
         "transactions": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/transactions"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/transactions"
         },
         "authorizations": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/authorizations"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/authorizations"
         },
         "captures": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/captures"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/captures"
         },
         "reversals": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/reversals"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/reversals"
         },
         "cancellations": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/cancellations"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/cancellations"
         },
         "payeeInfo": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeInfo"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/payeeInfo"
         },
         "urls": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/urls"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/urls"
         },
         "settings": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/settings"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/settings"
         },
         "approvedLegalAddress": {
-            "id": "/psp/invoice/payments/<paymentId>/approvedlegaladdress"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress"
         },
         "maskedApprovedLegalAddress": {
-            "id": "/psp/invoice/payments/<paymentId>/maskedapprovedlegaladdress"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/maskedapprovedlegaladdress"
         }
     },
     "approvedLegalAddress": {
-        "id": "/psp/invoice/payments/<paymentId>/approvedlegaladdress"
+        "id": "/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress"
     },
     "operations": [
         {
-            "href": "https://api.payex.com/psp/invoice/payments/<paymentId>/captures",
+            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/captures",
             "rel": "create-capture",
             "method": "POST"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/<paymentId>/cancellations",
+            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/cancellations",
             "rel": "create-cancel",
             "method": "POST"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/<paymentId>/approvedlegaladdress",
+            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
             "rel": "create-approved-legal-address",
             "method": "POST"
         }

--- a/payments/invoice/redirect.md
+++ b/payments/invoice/redirect.md
@@ -396,22 +396,22 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-    "href": "https://merchant/cancelUrl",
+    "href": "https://example.com/cancelUrl",
     "rel": "redirect-merchant-cancel",
     "method": "GET"
 }
 {
-    "href": "https://merchant/completeUrl",
+    "href": "https://example.com/completeUrl",
     "rel": "redirect-merchant-complete",
     "method": "GET"
 }
 {
-    "href": "https://merchant/cancelUrl",
+    "href": "https://example.com/cancelUrl",
     "rel": "redirect-merchant-cancel",
     "method": "GET"
 }
 {
-    "href": "https://merchant/completeUrl",
+    "href": "https://example.com/completeUrl",
     "rel": "redirect-merchant-complete",
     "method": "GET"
 }

--- a/payments/invoice/redirect.md
+++ b/payments/invoice/redirect.md
@@ -269,17 +269,17 @@ Content-Type: application/json
     },
     "operations": [
         {
-            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}",
             "rel": "update-payment-abort",
             "method": "PATCH"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/authorizations",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}/authorizations",
             "rel": "create-authorize",
             "method": "POST"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
             "rel": "create-approved-legal-address",
             "method": "POST"
         }
@@ -299,7 +299,7 @@ possible to perform in the current state of the payment.
 
 ```http
 GET /psp/invoice/payments/{{ page.paymentId }}/ HTTP/1.1
-Host: api.payex.com
+Host: api.externalintegration.payex.com
 Authorization: Bearer <AccessToken>
 Content-Type: application/json
 ```
@@ -369,17 +369,17 @@ Content-Type: application/json
     },
     "operations": [
         {
-            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/captures",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}/captures",
             "rel": "create-capture",
             "method": "POST"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/cancellations",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}/cancellations",
             "rel": "create-cancel",
             "method": "POST"
         },
         {
-            "href": "https://api.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
             "rel": "create-approved-legal-address",
             "method": "POST"
         }

--- a/payments/invoice/seamless-view.md
+++ b/payments/invoice/seamless-view.md
@@ -120,7 +120,7 @@ invoice information. This will generate a payment object with a unique
 Different countries have different values for the properties. The table below
 showcase the values for the respective countries:
 
-**POST Request Options**
+#### POST Request Options
 
 {:.table .table-striped}
 |               | Norway ![Norwegian flag][no-png] | FInland ![Finish flag][fi-png] | Sweden ![Swedish flag][se-png] |
@@ -190,7 +190,7 @@ Content-Type: application/json
             "termsOfServiceUrl": "http://example.com/payment-terms.pdf"
         },
         "payeeInfo": {
-            "payeeId": "12345678-1234-1234-1234-123456789012",
+            "payeeId": "{{ page.merchantId }}",
             "payeeReference": "CD1234",
             "payeeName": "Merchant1",
             "productCategory": "A123"
@@ -242,7 +242,7 @@ Content-Type: application/json
 
 {
     "payment": {
-        "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+        "id": "/psp/invoice/payments/{{ page.paymentId }}",
         "number": 1234567890,
         "instrument": "Invoice",
         "created": "YYYY-MM-DDThh:mm:ssZ",
@@ -252,7 +252,7 @@ Content-Type: application/json
         "state": "Ready",
         "currency": "SEK",
         "prices": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/prices"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/prices"
         },
         "amount": 0,
         "description": "Test Purchase",
@@ -260,31 +260,31 @@ Content-Type: application/json
         "userAgent": "Mozilla/5.0...",
         "language": "sv-SE",
         "urls": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/urls"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/urls"
         },
         "payeeInfo": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/payeeinfo"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/payeeinfo"
         },
         "metadata": {
-            "id": "/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/metadata"
+            "id": "/psp/invoice/payments/{{ page.paymentId }}/metadata"
         }
     },
     "operations": [
         {
             "method": "POST",
-            "href": "https://api.stage.payex.com/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/approvedlegaladdress",
+            "href": "https://api.stage.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
             "rel": "create-approved-legal-address",
             "contentType": "application/json"
         },
         {
             "method": "POST",
-            "href": "https://api.stage.payex.com/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c/authorizations",
+            "href": "https://api.stage.payex.com/psp/invoice/payments/{{ page.paymentId }}/authorizations",
             "rel": "create-authorization",
             "contentType": "application/json"
         },
         {
             "method": "PATCH",
-            "href": "https://api.stage.payex.com/psp/invoice/payments/5adc265f-f87f-4313-577e-08d3dca1a26c",
+            "href": "https://api.stage.payex.com/psp/invoice/payments/{{ page.paymentId }}",
             "rel": "update-payment-abort",
             "contentType": "application/json"
         },

--- a/payments/invoice/seamless-view.md
+++ b/payments/invoice/seamless-view.md
@@ -10,7 +10,7 @@ sidebar:
       title: Redirect
     - url: /payments/invoice/seamless-view
       title: Seamless View
-    - url: /payments/invoice/direct 
+    - url: /payments/invoice/direct
       title: Direct
     - url: /payments/invoice/after-payment
       title: After Payment
@@ -272,31 +272,31 @@ Content-Type: application/json
     "operations": [
         {
             "method": "POST",
-            "href": "https://api.stage.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}/approvedlegaladdress",
             "rel": "create-approved-legal-address",
             "contentType": "application/json"
         },
         {
             "method": "POST",
-            "href": "https://api.stage.payex.com/psp/invoice/payments/{{ page.paymentId }}/authorizations",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}/authorizations",
             "rel": "create-authorization",
             "contentType": "application/json"
         },
         {
             "method": "PATCH",
-            "href": "https://api.stage.payex.com/psp/invoice/payments/{{ page.paymentId }}",
+            "href": "https://api.externalintegration.payex.com/psp/invoice/payments/{{ page.paymentId }}",
             "rel": "update-payment-abort",
             "contentType": "application/json"
         },
         {
             "method": "GET",
-            "href": "https://ecom.stage.payex.com/invoice/payments/authorize/ce98e5fa397de21b64cb4aa932aad81cf2ef18736cb9d975c82466a495cbe3bc",
+            "href": "https://ecom.externalintegration.payex.com/invoice/payments/authorize/ce98e5fa397de21b64cb4aa932aad81cf2ef18736cb9d975c82466a495cbe3bc",
             "rel": "redirect-authorization",
             "contentType": "text/html"
         },
         {
             "method": "GET",
-            "href": "https://ecom.stage.payex.com/invoice/core/scripts/client/px.invoice.client.js?<token>&operation=authorize",
+            "href": "https://ecom.externalintegration.payex.com/invoice/core/scripts/client/px.invoice.client.js?<token>&operation=authorize",
             "rel": "view-authorization",
             "contentType": "application/javascript"
         }

--- a/payments/swish/other-features.md
+++ b/payments/swish/other-features.md
@@ -147,12 +147,12 @@ Content-Type: application/json
     "operations": [
         {
             "method": "PATCH",
-            "href": "http://localhost:18496/psp/swish/payments/{{ page.paymentId }}",
+            "href": "http://api.externalintegration.payex.com/psp/swish/payments/{{ page.paymentId }}",
             "rel": "update-payment-abort"
         },
         {
             "method": "POST",
-            "href": "http://localhost:18496/psp/swish/payments/{{ page.paymentId }}/sales",
+            "href": "http://api.externalintegration.payex.com/psp/swish/payments/{{ page.paymentId }}/sales",
             "rel": "create-sale"
         }
 

--- a/payments/swish/seamless-view.md
+++ b/payments/swish/seamless-view.md
@@ -300,7 +300,7 @@ Content-Type: application/json
             "rel": "create-sale"
       },
       {
-        "href": "https://ecom.payex.com/swish/payments/authorize/123456123412341234123456789012",
+        "href": "https://ecom.externalintegration.payex.com/swish/payments/authorize/123456123412341234123456789012",
         "rel": "redirect-sale",
         "method": "GET",
         "contentType": "text/html"

--- a/payments/vipps/other-features.md
+++ b/payments/vipps/other-features.md
@@ -216,7 +216,7 @@ the problem.
 ### Error types from Vipps (Init-call)
 
 All Vipps error types will have the following URI in front of type:
-`https://api.payex.com/psp/errordetail/vipps/<errorType>`
+`https://api.payex.com/psp/errordetail/vipps/<error-type>`
 
 {:.table .table-striped}
 | Type          | Status | Note       |
@@ -226,7 +226,7 @@ All Vipps error types will have the following URI in front of type:
 ### Error types from Vipps (Callback)
 
 All Vipps error types will have the following URI in front of type:
-`https://api.payex.com/psp/errordetail/vipps/<errorType>`
+`https://api.payex.com/psp/errordetail/vipps/<error-type>`
 
 {:.table .table-striped}
 | Type             | Status | Note                       |
@@ -236,7 +236,7 @@ All Vipps error types will have the following URI in front of type:
 ### Error types from Acquirer
 
 All Vipps error types will have the following URI in front of type:
-`https://api.payex.com/psp/errordetail/vipps/<errorType>`
+`https://api.payex.com/psp/errordetail/vipps/<error-type>`
 
 {:.table .table-striped}
 | Type | Status | Note

--- a/payments/vipps/redirect.md
+++ b/payments/vipps/redirect.md
@@ -230,17 +230,17 @@ Content-Type: application/json
     "operations": [
         {
             "method": "POST",
-            "href": "http://localhost:15486/psp/vipps/payments/c50eef6d-a788-4ec6-64ff-08d4b16740a4/authorizations",
+            "href": "http://api.externalintegration.payex.com/psp/vipps/payments/c50eef6d-a788-4ec6-64ff-08d4b16740a4/authorizations",
             "rel": "create-authorization"
         },
         {
             "method": "PATCH",
-            "href": "http://localhost:15486/psp/vipps/payments/c50eef6d-a788-4ec6-64ff-08d4b16740a4",
+            "href": "http://api.externalintegration.payex.com/psp/vipps/payments/c50eef6d-a788-4ec6-64ff-08d4b16740a4",
             "rel": "update-payment-abort"
         },
         {
             "method": "GET",
-            "href": "http://localhost:15487/vipps/payments/authorize/8fb05a835f2fc227dc7bca9abaf649b919ba8a572deb448bff543dd5806dacb7",
+            "href": "http://api.externalintegration.payex.com/vipps/payments/authorize/8fb05a835f2fc227dc7bca9abaf649b919ba8a572deb448bff543dd5806dacb7",
             "rel": "redirect-authorization"
         }
     ]
@@ -287,7 +287,7 @@ transactions made on a specific payment.
 HTTP/1.1 200 OK
 Content-Type: application/json
 GET /psp/vipps/payments/84b9e6aa-b8f5-4e7f-fa2f-08d612f7dd5d/authorizations/<transactionId> HTTP/1.1
-Host: api.payex.com
+Host: api.externalintegration.payex.com
 Authorization: Bearer <MerchantToken>
 
 


### PR DESCRIPTION
Updated all sections in invoice to use the new global guids.
Also added a new MerchantId that we can use where we want, currently used for payeeId.
While the name of `MerchantId` might not fit the usage currently, I believe `MerchantId` is more natural to use other places if we ever need it instead of `payeeId`.