### PR TITLE
Fixed table formatting

### DIFF
--- a/payments/mobile-pay/other-features.md
+++ b/payments/mobile-pay/other-features.md
@@ -169,6 +169,7 @@ Content-Type: application/json
 }
 ```
 
+{:.table .table-striped}
 | Property                                     | Data type    | Description                                                                                                                                                                                      |
 | :------------------------------------------- | :----------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `payment`                                    | `object`     | The payment object contains information about the retrieved payment.                                                                                                                             |


### PR DESCRIPTION
Under "Create payment" and before "Payment", there was a missing statement for table formatting, meaning the table did not match the visual look of the others.