### PR TITLE
Minor fixes

### DIFF
--- a/_includes/alert-agreement-required.md
+++ b/_includes/alert-agreement-required.md
@@ -1,0 +1,2 @@
+{% include alert.html type="warning" icon="warning" body="This feature is only
+available for merchants who have a specific agreement with Swedbank Pay." %}

--- a/_includes/unscheduled-purchase.md
+++ b/_includes/unscheduled-purchase.md
@@ -22,7 +22,7 @@ Content-Type: application/json
 {
     "payment": {
         "operation": "UnscheduledPurchase",
-        "intent": "Authorization|AutoCapture",
+        "intent": "Authorization",
         "paymentToken": "{{ page.paymentId }}",
         "currency": "NOK",
         "amount": 1500,
@@ -56,9 +56,9 @@ Content-Type: application/json
     "number": 1234567890,
     "created": "2016-09-14T13:21:29.3182115Z",
     "updated": "2016-09-14T13:21:57.6627579Z",
-    "state": "Ready|Pending|Failed|Aborted",
+    "state": "Ready",
     "operation": "PurchaseDirect",
-    "intent": "Authorization|AutoCapture",
+    "intent": "Authorization",
     "currency": "NOK",
     "amount": 1500,
     "remainingCaptureAmount": 1500,

--- a/_includes/unscheduled-purchase.md
+++ b/_includes/unscheduled-purchase.md
@@ -1,14 +1,14 @@
 ## Unscheduled Purchase
 
 An `unscheduled purchase`, also called a Merchant Initiated Transaction (MIT),
-is a payment which uses a `paymentToken` created through a previous payment in
+is a payment which uses a `paymentToken` generated through a previous payment in
 order to charge the same card at a later time. They are done by the merchant
 without the cardholder being present.  
 
-`unscheduled purchase`s differ from `recur` as they are done as singular
-transactions, and not recurring ones. Examples of this can be car rental
-companies charging the payer's card for toll road expenses after the rental
-period.
+`unscheduled purchase`s differ from `recur` as they are not meant to be
+recurring, but occur as singular transactions. Examples of this can be car
+rental companies charging the payer's card for toll road expenses after the
+rental period.
 
 {:.code-header}
 **Request**
@@ -22,12 +22,12 @@ Content-Type: application/json
 {
     "payment": {
         "operation": "UnscheduledPurchase",
-        "intent": "Authorization",
+        "intent": "Authorization|AutoCapture",
         "paymentToken": "{{ page.paymentId }}",
         "currency": "NOK",
         "amount": 1500,
         "vatAmount": 0,
-        "description": "Test Recurrence",
+        "description": "Test Unscheduled",
         "userAgent": "Mozilla/5.0...",
         "language": "nb-NO",
         "urls": {
@@ -58,7 +58,7 @@ Content-Type: application/json
     "updated": "2016-09-14T13:21:57.6627579Z",
     "state": "Ready|Pending|Failed|Aborted",
     "operation": "PurchaseDirect",
-    "intent": "Authorization",
+    "intent": "Authorization|AutoCapture",
     "currency": "NOK",
     "amount": 1500,
     "remainingCaptureAmount": 1500,

--- a/_includes/unscheduled-purchase.md
+++ b/_includes/unscheduled-purchase.md
@@ -1,5 +1,7 @@
 ## Unscheduled Purchase
 
+{% include alert-agreement-required.md %}
+
 An `unscheduled purchase`, also called a Merchant Initiated Transaction (MIT),
 is a payment which uses a `paymentToken` generated through a previous payment in
 order to charge the same card at a later time. They are done by the merchant

--- a/payments/swish/after-payment.md
+++ b/payments/swish/after-payment.md
@@ -107,7 +107,8 @@ request for the given operation.
 
 ## Swish transactions
 
-All Swish transactions are described below.
+All Swish transactions are described below. Please note that Swish does not
+support [Merchant Initiated Transactions][MIT-section] for the time being.
 
 ## Sales
 
@@ -432,3 +433,4 @@ Swish does not support `recurring` payments.
 [technical-reference-problemmessages]: /payments/swish/other-features#problem-messages
 [technical-reference-transaction]: /payments/swish/other-features#transaction
 [user-agent]: https://en.wikipedia.org/wiki/User_agent
+[MIT-section]: /payments/card/other-features#unscheduled-purchase


### PR DESCRIPTION
Did some minor textual and request changes.

The wiki request/response has both authorization and autocapture as intent. I wanted to add authorization only, since we aren't supposed tu encourage use of AutoCapture, but I wanted to keep it in until talking to Kristiansen tomorrow.

Perhaps a flow chart would be nice as well?