### PR TITLE
Fix typo

### DIFF
--- a/checkout/payment-menu.md
+++ b/checkout/payment-menu.md
@@ -228,7 +228,7 @@ request.addEventListener('load', function () {
                         // Payment Menu inside our 'payment-menu' container.
                         payex.hostedView.paymentMenu({
                             container: 'payment-menu',
-                            culture: 'sv'
+                            culture: 'sv-SE'
                         }).open();
                     };
                     // Append the Payment Menu script to the <head>


### PR DESCRIPTION
`sv` should be `sv-SE` in the payment menu front-end example.