### PR TITLE
DX-980: Remove livereload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,11 @@
 name: Deploy to GitHub Pages
 
-on: 
+on:
   push:
     branches: [ master ]
 
 jobs:
-  build:
-    name: Deploy to GitHub Pages
+  deploy:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -5,7 +5,6 @@ on:
 name: Automatic Rebase
 jobs:
   rebase:
-    name: Rebase
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/verify_build_output.yml
+++ b/.github/workflows/verify_build_output.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 jobs:
   verify:
-    name: Verify
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ opengraph:
   image: /assets/img/swedbank-pay-developer-portal.png
 design_guide:
   base_url: https://design.swedbankpay.com
-  version: 4.7.0
+  version: 4.6.1
 search:
   enabled: true
   url: /search

--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ opengraph:
   image: /assets/img/swedbank-pay-developer-portal.png
 design_guide:
   base_url: https://design.swedbankpay.com
-  version: 4.5.0
+  version: 4.7.0
 search:
   enabled: true
   url: /search

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 repository: SwedbankPay/developer.swedbankpay.com
-remote_theme: SwedbankPay/swedbank-pay-design-guide-jekyll-theme@1.4.5
+remote_theme: SwedbankPay/swedbank-pay-design-guide-jekyll-theme@1.5
 exclude: ["Gemfile*", "Rakefile"]
 plugins:
   - "jekyll-github-metadata"

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 repository: SwedbankPay/developer.swedbankpay.com
-remote_theme: SwedbankPay/swedbank-pay-design-guide-jekyll-theme@1.4.4
+remote_theme: SwedbankPay/swedbank-pay-design-guide-jekyll-theme@1.4.5
 exclude: ["Gemfile*", "Rakefile"]
 plugins:
   - "jekyll-github-metadata"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   portal:
     container_name: developer_portal
-    image: swedbankpay/jekyll-plantuml:1.3.7
+    image: swedbankpay/jekyll-plantuml:1.3.8
     ports:
       - 4000:4000
       - 35729:35729

--- a/index.md
+++ b/index.md
@@ -8,10 +8,6 @@ sidebar:
       title: Technical Information
 ---
 
-{% assign design_guide_base_url = design_guide_version_url | default: 'https://design.swedbankpay.com' %}
-{% assign design_guide_version = site.design_guide.version | default: '4.1.0' %}
-{% assign design_guide_version_url = design_guide_base_url | append: '/v/' | append: design_guide_version %}
-
 Hi! Welcome to the **Swedbank Pay Developer Portal**.
 
 ### New to our API Platform?


### PR DESCRIPTION
Removes the `livereload.js` script by upgrading to version 1.5 of the theme and version 1.3.8 of `jekyll-plantuml`. Also upgrades the Design Guide to version 4.6.1 for good measure.