### PR TITLE
Updated documentation mismatch regarding "noCvc"

### DIFF
--- a/_includes/one-click-payments.md
+++ b/_includes/one-click-payments.md
@@ -90,7 +90,7 @@ Content-Type: application/json
         "paymentToken": "{{ page.payment_token }}"
     },
     "creditCard": {
-        "noCVC": true
+        "noCvc": true
     }
 }
 ```


### PR DESCRIPTION
In the table below the code example it says this parameter is called "noCvc" which is also what I use in my implementation.