### PR TITLE
Update contributing.md

### DIFF
--- a/resources/development-guidelines/contributing.md
+++ b/resources/development-guidelines/contributing.md
@@ -45,7 +45,7 @@ If you choose option 3 (forking the repository), then please read on.
 ## Making Changes
 
 *   Create a new [branch][branching] from where you want to base your work.
-    *   This is usually the `master` branch.
+    *   This is usually the `develop` branch.
     *   Please avoid working directly on the `master` branch.
 *   Make [commits][commit] of logical units in the new branch.
 *   Check for unnecessary whitespace with `git diff --check` before committing.

--- a/resources/development-guidelines/contributing.md
+++ b/resources/development-guidelines/contributing.md
@@ -46,7 +46,7 @@ If you choose option 3 (forking the repository), then please read on.
 
 *   Create a new [branch][branching] from where you want to base your work.
     *   This is usually the `master` or `develop` branch.
-    *   Please avoid working directly on the `master` branch.
+    *   Please avoid working directly on the `master` and `develop` branch.
 *   Make [commits][commit] of logical units in the new branch.
 *   Check for unnecessary whitespace with `git diff --check` before committing.
 *   Make sure your [commit messages][commit-practice] are well written and in the

--- a/resources/development-guidelines/contributing.md
+++ b/resources/development-guidelines/contributing.md
@@ -45,7 +45,7 @@ If you choose option 3 (forking the repository), then please read on.
 ## Making Changes
 
 *   Create a new [branch][branching] from where you want to base your work.
-    *   This is usually the `develop` branch.
+    *   This is usually the `master` or `develop` branch.
     *   Please avoid working directly on the `master` branch.
 *   Make [commits][commit] of logical units in the new branch.
 *   Check for unnecessary whitespace with `git diff --check` before committing.


### PR DESCRIPTION
Change from master to develop when directing people to where to base their work.
The initial idea was to avoid having contributors branch of and opening pull requests to our `master` branch.