### PR TITLE
DX-1064: Authenticate HTMLProofer requests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   portal:
     container_name: developer_portal
-    image: swedbankpay/jekyll-plantuml:2.0.3
+    image: swedbankpay/jekyll-plantuml:2.0.4
     command: serve
     ports:
       - 4000:4000


### PR DESCRIPTION
Upgrade jekyll-plantuml to version 2.0.4 to get SwedbankPay/jekyll-plantuml-docker#34 that pass auth token from environment variable to HTMLProofer to avoid GitHub responding with `429 Too Many Requests`. 