### PR TITLE
Release 1.13.3 (develop)

### DIFF
--- a/resources/release-notes.md
+++ b/resources/release-notes.md
@@ -36,9 +36,9 @@ this very documentation, not to a version of any APIs described by it." %}
 *   Added documentation on deprecated operations in [Checkout][checkout-payment-order-purchase].
 *   Updated `instrument` description in [Checkout][checkout].
 *   Updated `payeeReference` description.
-*   Clarified `msisdn` and `shopogoUrl` in [Swish Payments][swish].
+*   Clarified `msisdn` and `shopogoUrl` in [MobilePay Payments][mobile-pay].
 *   Updated [Test data][test-data] in [Resources][resources].
-*   Documented problems in [MobilePay Payments][mobile-pay].
+*   Documented problems in [Trustly Payments][trustly-payments].
 *   Added an alert for two-phase payments in Capture pages.
 
 ## 28 Aug 2020

--- a/resources/release-notes.md
+++ b/resources/release-notes.md
@@ -36,7 +36,7 @@ this very documentation, not to a version of any APIs described by it." %}
 *   Added documentation on deprecated operations in [Checkout][checkout-payment-order-purchase].
 *   Updated `instrument` description in [Checkout][checkout].
 *   Updated `payeeReference` description.
-*   Clarified `msisdn` and `shopogoUrl` in [MobilePay Payments][mobile-pay].
+*   Clarified `msisdn` and `shoplogoUrl` in [MobilePay Payments][mobile-pay].
 *   Updated [Test data][test-data] in [Resources][resources].
 *   Documented problems in [Trustly Payments][trustly-payments].
 *   Added an alert for two-phase payments in Capture pages.

--- a/resources/release-notes.md
+++ b/resources/release-notes.md
@@ -29,10 +29,22 @@ published on this page." %}
 body="The version numbers used in headers on this page refers to the version of
 this very documentation, not to a version of any APIs described by it." %}
 
+## 04 Sep 2020
+
+### Version 1.13.3
+
+*   Added documentation on deprecated operations in [Checkout][checkout-payment-order-purchase].
+*   Updated `instrument` description in [Checkout][checkout].
+*   Updated `payeeReference` description.
+*   Clarified `msisdn` and `shopogoUrl` in [Swish Payments][swish].
+*   Updated [Test data][test-data] in [Resources][resources].
+*   Documented problems in [Trustly Payments][trustly-other-features].
+*   Added an alert for two-phase payments in Capture pages.
+
 ## 28 Aug 2020
 
 ### Version 1.13.2
- 
+
 *   Added description on `metadata` for all payment instruments. 
 *   Updated files in [Settlement & Reconciliation][settlement-reconcilitation].
 *   Added information on token deletion in [Card Payments][card] and [Invoice Payments][invoice]. 
@@ -486,6 +498,7 @@ integration and the payer.
 [payment-orders]: /checkout/other-features#creating-a-payment-order
 [payments]: /payments
 [update-order-checkout]: /checkout/other-features#update-order
+[resources]: /resources/
 [settlement-reconcilitation]: /payments/card/other-features#settlement-and-reconciliation
 [sdk-modules]: /modules-sdks
 [storing-uri]: /home/technical-information#storing-uris

--- a/resources/release-notes.md
+++ b/resources/release-notes.md
@@ -38,19 +38,19 @@ this very documentation, not to a version of any APIs described by it." %}
 *   Updated `payeeReference` description.
 *   Clarified `msisdn` and `shopogoUrl` in [Swish Payments][swish].
 *   Updated [Test data][test-data] in [Resources][resources].
-*   Documented problems in [Trustly Payments][trustly-other-features].
+*   Documented problems in [MobilePay Payments][mobile-pay].
 *   Added an alert for two-phase payments in Capture pages.
 
 ## 28 Aug 2020
 
 ### Version 1.13.2
 
-*   Added description on `metadata` for all payment instruments. 
+*   Added description on `metadata` for all payment instruments.
 *   Updated files in [Settlement & Reconciliation][settlement-reconcilitation].
-*   Added information on token deletion in [Card Payments][card] and [Invoice Payments][invoice]. 
+*   Added information on token deletion in [Card Payments][card] and [Invoice Payments][invoice].
 *   Updated the documentation on `paymentRestrictedToAgeLimit` and
-    `paymentRestrictedToSocialSecurityNumber` in [Swish Payments][swish]. 
-*   Added documentation on guest checkout in [Checkout][checkout]. 
+    `paymentRestrictedToSocialSecurityNumber` in [Swish Payments][swish].
+*   Added documentation on guest checkout in [Checkout][checkout].
 *   Updated information about `logourl` in [Checkout][checkout].
 *   Added a list of accepted banks in [Trustly Payments][trustly-payments].
 *   Updated the `UpdateOrder` description in [Checkout][checkout].
@@ -59,11 +59,11 @@ this very documentation, not to a version of any APIs described by it." %}
 
 ### Version 1.13.1
 
-*   Removed documentation for [Trustly Payments][trustly-payments] Seamless View. 
+*   Removed documentation for [Trustly Payments][trustly-payments] Seamless View.
 *   Updated `reOrderPurchaseIndicator` description.
-*   Updated [Other Features][trustly-other-features] in [Trustly Payments][trustly-payments]. 
-*   Updated [Test Data][test-data] for Vipps Payments. 
-*   Added updated documentation on the `transaction` operation. 
+*   Updated [Other Features][trustly-other-features] in [Trustly Payments][trustly-payments].
+*   Updated [Test Data][test-data] for Vipps Payments.
+*   Added updated documentation on the `transaction` operation.
 
 ## 17 July 2020
 


### PR DESCRIPTION
Version 1.13.3

*   Added documentation on deprecated operations in Checkout..
*   Updated `instrument` description in Checkout.
*   Updated `payeeReference` description.
*   Clarified `msisdn` and `shoplogoUrl` in MobilePay Payments.
*   Updated Test data in Resources.
*   Documented problems in Trustly Payments.
*   Added an alert for two-phase payments in Capture pages.
