### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     sprockets-sass (1.3.1)
       sprockets (~> 2.0)
       tilt (~> 1.1)
-    swedbank-pay-design-guide-jekyll-theme (1.7)
+    swedbank-pay-design-guide-jekyll-theme (1.7.1)
       faraday (>= 1.0.1)
       html-proofer
       jekyll (>= 3.7, < 5.0)


### PR DESCRIPTION
This updates the theme with a new setting that by default hides the merchant bar