### PR TITLE
Feature/esm 964 digital products in checkin

### DIFF
--- a/checkout/checkin.md
+++ b/checkout/checkin.md
@@ -57,6 +57,7 @@ Content-Type: application/json
 {
     "token": "7e380fbb3196ea76cc45814c1d99d59b66db918ce2131b61f585645eff364871",
     "operations": [
+        // Deprecated operation. Do not use!
         {
             "method": "GET",
             "rel": "redirect-consumer-identification",

--- a/checkout/checkin.md
+++ b/checkout/checkin.md
@@ -32,7 +32,8 @@ Content-Type: application/json
 {
     "operation": "initiate-consumer-session",
     "language": "sv-SE",
-    "shippingAddressRestrictedToCountryCodes" : ["NO", "SE", "DK"]
+    "shippingAddressRestrictedToCountryCodes" : ["NO", "SE", "DK"],
+    "requireShippingAddress": true
 }
 ```
 
@@ -42,6 +43,7 @@ Content-Type: application/json
 | {% icon check %} | `operation`                               | `string` | `initiate-consumer-session`, the operation to perform.                                                                                 |
 | {% icon check %} | `language`                                | `string` | Selected language to be used in Checkin. Supported values are {% include field-description-language.md api_resource="paymentorders" %} |
 | {% icon check %} | `shippingAddressRestrictedToCountryCodes` | `string` | List of supported shipping countries for merchant. Using ISO-3166 standard.                                                            |
+|                  | `requireShippingAddress` | `bool` | Defaults to true. If set to false we wil not collect a shipping address from the consumer.                                                            |
 
 When the request has been sent, a response containing an array of operations that can be acted upon will be returned:
 


### PR DESCRIPTION
We have added a new parameter `RequireShippingAddress` to the initiate-consumer-session operation. This adds support for digital products where no address information is required by the merchant.

When this flag is set to `false` the checkin process is streamlined by not prompting the user to provide an address. This also means that we will not fire off the events for `onShippingDetailsAvailable` and `onBillingDetailsAvailable` as there will be no address for the merchant to collect.

To preserve backwards compatibilty the field is optional and the default behaviour is to collect address information.