### PR TITLE
DX-1199: Add back redirect_from to Modules & SDKs

### DIFF
--- a/modules-sdks/index.md
+++ b/modules-sdks/index.md
@@ -1,5 +1,6 @@
 ---
 title: Modules & SDKs Introduction
+redirect_from: /resources/sdk-modules
 estimated_read: 30
 description: |
   We have multiple Open Source-based SDKs and Modules to use with


### PR DESCRIPTION
Add back the `redirect_from` front matter directive that was nuked in ea6db6ca4804a2ff7cfea623b06fea52901951df.