### PR TITLE
DX-1309 Text in amount include

### DIFF
--- a/_includes/field-description-amount.md
+++ b/_includes/field-description-amount.md
@@ -3,7 +3,7 @@
 {% assign currency = "SEK" %}
 {% endif %}
 {%- capture amount_text -%}
-The amount (including VAT, if any) to charge the payer, entered in the lowest monetary unit of the selected currency. E.g.:&nbsp;
+The transaction amount (including VAT, if any) entered in the lowest monetary unit of the selected currency. E.g.:&nbsp;
 **`10000`** = `100.00` {{ currency }},&nbsp;
 **`5000`** = `50.00` {{ currency }}.
 {%- endcapture -%}


### PR DESCRIPTION
Tried to make it a bit more general. Used "transaction" instead of payment, as the payment consists of one or more transactions. This way we are including the reversals and cancellations as well.