### PR TITLE
ESM-1311 Upate Checkin with new flow

### DIFF
--- a/checkout/checkin.md
+++ b/checkout/checkin.md
@@ -43,7 +43,7 @@ Content-Type: application/json
 | :--------------: | :---------------------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------- |
 | {% icon check %} | `operation`                               | `string` | `initiate-consumer-session`, the operation to perform.                                                                                 |
 | {% icon check %} | `language`                                | `string` | Selected language to be used in Checkin. Supported values are {% include field-description-language.md %} |
-|                  | `shippingAddressRestrictedToCountryCodes` | `string` | List of supported shipping countries for merchant. Using [ISO-3166](https://www.iso.org/iso-3166-country-codes.html) standard. This is required unless `requireShippingAddress` is set to false.                                                           |
+|                  | `shippingAddressRestrictedToCountryCodes` | `string` | List of supported shipping countries for merchant. Using [ISO-3166][iso-3166-site] standard. This is required unless `requireShippingAddress` is set to false.                                                           |
 |                  | `requireShippingAddress` | `bool` | Defaults to true. If set to false we will not collect a shipping address from the consumer.                                                            |
 
 When the request has been sent, a response containing an array of operations that can be acted upon will be returned:
@@ -286,3 +286,4 @@ and its duration.
 [checkin-events]: /checkout/other-features#checkin-events
 [data-protection]: /resources/data-protection#paymentorder-consumer-data
 [payment-menu]: payment-menu
+[iso-3166-site]: https://www.iso.org/iso-3166-country-codes.html

--- a/checkout/checkin.md
+++ b/checkout/checkin.md
@@ -43,7 +43,7 @@ Content-Type: application/json
 | :--------------: | :---------------------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------- |
 | {% icon check %} | `operation`                               | `string` | `initiate-consumer-session`, the operation to perform.                                                                                 |
 | {% icon check %} | `language`                                | `string` | Selected language to be used in Checkin. Supported values are {% include field-description-language.md %} |
-|                  | `shippingAddressRestrictedToCountryCodes` | `string` | List of supported shipping countries for merchant. Using ISO-3166 standard. This is required unless `requireShippingAddress` is set to false.                                                           |
+|                  | `shippingAddressRestrictedToCountryCodes` | `string` | List of supported shipping countries for merchant. Using [ISO-3166](https://www.iso.org/iso-3166-country-codes.html) standard. This is required unless `requireShippingAddress` is set to false.                                                           |
 |                  | `requireShippingAddress` | `bool` | Defaults to true. If set to false we will not collect a shipping address from the consumer.                                                            |
 
 When the request has been sent, a response containing an array of operations that can be acted upon will be returned:

--- a/checkout/checkin.md
+++ b/checkout/checkin.md
@@ -43,7 +43,7 @@ Content-Type: application/json
 | :--------------: | :---------------------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------- |
 | {% icon check %} | `operation`                               | `string` | `initiate-consumer-session`, the operation to perform.                                                                                 |
 | {% icon check %} | `language`                                | `string` | Selected language to be used in Checkin. Supported values are {% include field-description-language.md %} |
-| {% icon check %} | `shippingAddressRestrictedToCountryCodes` | `string` | List of supported shipping countries for merchant. Using ISO-3166 standard.                                                            |
+|                  | `shippingAddressRestrictedToCountryCodes` | `string` | List of supported shipping countries for merchant. Using ISO-3166 standard. This is required unless `requireShippingAddress` is set to false.                                                           |
 |                  | `requireShippingAddress` | `bool` | Defaults to true. If set to false we will not collect a shipping address from the consumer.                                                            |
 
 When the request has been sent, a response containing an array of operations that can be acted upon will be returned:

--- a/checkout/checkin.md
+++ b/checkout/checkin.md
@@ -43,7 +43,7 @@ Content-Type: application/json
 | :--------------: | :---------------------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------- |
 | {% icon check %} | `operation`                               | `string` | `initiate-consumer-session`, the operation to perform.                                                                                 |
 | {% icon check %} | `language`                                | `string` | Selected language to be used in Checkin. Supported values are {% include field-description-language.md %} |
-|                  | `shippingAddressRestrictedToCountryCodes` | `string` | List of supported shipping countries for merchant. Using [ISO-3166][iso-3166-site] standard. This is required unless `requireShippingAddress` is set to false.                                                           |
+|                  | `shippingAddressRestrictedToCountryCodes` | `string` | List of supported shipping countries for merchant. Using [ISO-3166] standard. This is required unless `requireShippingAddress` is set to false.                                                           |
 |                  | `requireShippingAddress` | `bool` | Defaults to true. If set to false we will not collect a shipping address from the consumer.                                                            |
 
 When the request has been sent, a response containing an array of operations that can be acted upon will be returned:
@@ -286,4 +286,4 @@ and its duration.
 [checkin-events]: /checkout/other-features#checkin-events
 [data-protection]: /resources/data-protection#paymentorder-consumer-data
 [payment-menu]: payment-menu
-[iso-3166-site]: https://www.iso.org/iso-3166-country-codes.html
+[iso-3166]: https://www.iso.org/iso-3166-country-codes.html


### PR DESCRIPTION
ESM-1311 Changes now reflect the new flow on initiate-consumer-session. shippingAddressRestrictedToCountryCodes should not be required when requireShippingAddres is set to false.