### PR TITLE
DX-1446: Bump jekyll-plantuml from version 2.1.1 to 2.1.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   portal:
     container_name: developer_portal
-    image: swedbankpay/jekyll-plantuml:2.1.1
+    image: swedbankpay/jekyll-plantuml:2.1.4
     command: serve
     ports:
       - 4000:4000


### PR DESCRIPTION
Bump jekyll-plantuml from version 2.1.1 to 2.1.4 for SwedbankPay/jekyll-plantuml-docker#91 so we get the Git branch injected into the Jekyll build process, hopefully producing URLs that don't lead to `404` on internal pull requests.