### PR TITLE
Remove references to particular versions of the mobile SDK components

### DIFF
--- a/modules-sdks/mobile-sdk/android.md
+++ b/modules-sdks/mobile-sdk/android.md
@@ -21,11 +21,7 @@ This guide assumes that you are using the Merchant Backend Configuration and you
 
 ## Installation
 
-The Android component of the Swedbank Pay Mobile SDK is distributed through JCenter, which is a default repository in Android Studio projects. Therefore, most applications can integrate the SDK by simply adding the dependency:
-
-`implementation 'com.swedbankpay.mobilesdk:mobilesdk:1.0.0-beta27'`
-
-\[Development note: There is not yet a stable release of the SDK.\]
+The Android component of the Swedbank Pay Mobile SDK is distributed through JCenter, which is a default repository in Android Studio projects. Therefore, most applications can integrate the SDK by simply adding the dependency. Please refer to the [Bintray page][sdk-bintray] for the latest version of the SDK.
 
 ## Usage
 
@@ -274,6 +270,7 @@ Note that there is an [argument][dokka-payfrag-argbuilder-usebrowser] for debugg
                          next_href="ios"
                          next_title="iOS" %}
 
+[sdk-bintray]: https://bintray.com/swedbankpay/swedbank-pay-sdk-android/swedbank-pay-sdk-android
 [dokka-pkg]: https://github.com/SwedbankPay/swedbank-pay-sdk-android/blob/dev/sdk/dokka_github/sdk/com.swedbankpay.mobilesdk/index.md
 [dokka-pkg-merch]: https://github.com/SwedbankPay/swedbank-pay-sdk-android/blob/dev/sdk/dokka_github/sdk/com.swedbankpay.mobilesdk.merchantbackend/index.md
 [dokka-payfrag]: https://github.com/SwedbankPay/swedbank-pay-sdk-android/blob/dev/sdk/dokka_github/sdk/com.swedbankpay.mobilesdk/-payment-fragment/index.md

--- a/modules-sdks/mobile-sdk/ios.md
+++ b/modules-sdks/mobile-sdk/ios.md
@@ -20,11 +20,7 @@ This guide assumes that you are using the Merchant Backend Configuration and you
 
 The iOS component of the Swedbank Pay Mobile SDK is distributed through [CocoaPods][cocoapods]. If you do not have CocoaPods installed on your development machine, please install it first according to the [instructions][cocoapods-gettingstarted] at the CocoaPods web page.
 
-[Add CocoaPods][cocoapods-using] to your project, if needed. Then, add the dependency:
-
-`pod 'SwedbankPaySDK', '0.3.7'`
-
-\[Development note: There is not yet a stable release of the SDK.\]
+[Add CocoaPods][cocoapods-using] to your project, if needed. Then, add the [SDK pod][sdk-pod].
 
 Do not forget to run `pod install` after editing the `Podfile`.
 
@@ -432,6 +428,7 @@ sequenceDiagram
                          next_href="custom-backend"
                          next_title="Next: Custom Backend" %}
 
+[sdk-pod]: https://cocoapods.org/pods/SwedbankPaySDK
 [cocoapods]: https://cocoapods.org/
 [cocoapods-gettingstarted]: https://guides.cocoapods.org/using/getting-started.html
 [cocoapods-using]: https://guides.cocoapods.org/using/using-cocoapods.html


### PR DESCRIPTION
Instead refer to distribution pages that should always reflect the latest releases.