### PR TITLE
DX-1507: Bump theme from v1.9.10 to v1.9.13 to anonymize IP addresses in GA (master)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    swedbank-pay-design-guide-jekyll-theme (1.9.10)
+    swedbank-pay-design-guide-jekyll-theme (1.9.13)
       faraday (>= 1.0.1)
       html-proofer
       jekyll (>= 3.7, < 5.0)


### PR DESCRIPTION
Bump theme from v1.9.10 to v1.9.13 to [anonymize IP addresses in Google Analytics](https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization).

