### PR TITLE
DX-1507: Bump theme from v1.9.12 to v1.9.13 to anonymize IP addresses in GA (develop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
       ffi (~> 1.9)
     sassc (2.4.0-x64-mingw32)
       ffi (~> 1.9)
-    swedbank-pay-design-guide-jekyll-theme (1.9.12)
+    swedbank-pay-design-guide-jekyll-theme (1.9.13)
       faraday (>= 1.0.1)
       html-proofer
       jekyll (>= 3.7, < 5.0)


### PR DESCRIPTION
Bump theme from v1.9.12 to v1.9.13 to [anonymize IP addresses in Google Analytics](https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization).