### PR TITLE
DX-969: Adjust release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,6 +16,9 @@ categories:
   - title: '🐛 Bug Fixes'
     labels:
       - 'fix'
+  - title: '⬆️ Dependencies'
+    labels:
+      - 'dependencies'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -25,9 +25,6 @@ version-resolver:
   minor:
     labels:
       - 'documentation'
-  patch:
-    labels:
-      - 'fix'
   default: patch
 template: |
   ## Changes


### PR DESCRIPTION
Adds a `dependencies` section to the release and removes the explicit increment of `patch` as `patch` is incremented by default.