### PR TITLE
DX-969: Add workflow for PR creation on release branch push

### DIFF
--- a/.github/scripts/variables.sh
+++ b/.github/scripts/variables.sh
@@ -51,13 +51,16 @@ initialize() {
 }
 
 generate_variables() {
+    release="${ref#refs/heads/release/}"
     # Remove the 'refs/*/' prefix from $ref to get the bare branch name.
     branch="${ref#refs/tags/}"
     branch="${branch#refs/heads/}"
 
     echo "Branch:     $branch"
+    echo "Release:    $release"
     echo "Repository: $repository_url"
     echo "::set-output name=branch::$branch"
+    echo "::set-output name=release::$release"
     echo "::set-output name=repository_url::$repository_url"
 }
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,47 @@
+name: Release PR
+
+on:
+  push:
+    branches:
+      - release/*
+
+jobs:
+  variables:
+    outputs:
+      release: ${{ steps.variables.outputs.release }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: variables
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: .github/scripts/variables.sh
+
+  release-develop-pr:
+    runs-on: ubuntu-latest
+    needs: variables
+    steps:
+      - uses: actions/checkout@v2
+      - uses: repo-sync/pull-request@v2
+        with:
+          destination_branch: develop
+          pr_title: Release ${{ needs.variables.outputs.release }} (develop)
+          pr_body: "## Release ${{ needs.variables.outputs.release }} (develop)"
+          pr_label: release
+          pr_draft: true
+          pr_allow_empty: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  release-master-pr:
+    runs-on: ubuntu-latest
+    needs: variables
+    steps:
+      - uses: actions/checkout@v2
+      - uses: repo-sync/pull-request@v2
+        with:
+          destination_branch: master
+          pr_title: Release ${{ needs.variables.outputs.release }} (master)
+          pr_body: "## Release ${{ needs.variables.outputs.release }} (master)"
+          pr_label: release
+          pr_draft: true
+          pr_allow_empty: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add GitHub Actions workflow that creates two pull requests (one for `develop` and one for `master`) when a `release/*` branch is pushed.