### PR TITLE
DX-1545: Remove settings node from payment order responses

### DIFF
--- a/_includes/payment-order-abort.md
+++ b/_includes/payment-order-abort.md
@@ -49,7 +49,6 @@ Content-Type: application/json
         "language": "nb-NO",
         "urls" : { "id": "/psp/paymentorders/{{ page.payment_order_id }}/urls" },
         "payeeInfo" : { "id": "/psp/paymentorders/{{ page.payment_order_id }}/payeeinfo" },
-        "settings": { "id": "/psp/paymentorders/{{ page.payment_order_id }}/settings" },
         "payers": { "id": "/psp/paymentorders/{{ page.payment_order_id }}/payers" },
         "orderItems" : { "id": "/psp/paymentorders/{{ page.payment_order_id }}/orderItems" },
         "metadata": { "id": "/psp/paymentorders/{{ page.payment_order_id }}/metadata" },

--- a/_includes/payment-order-get.md
+++ b/_includes/payment-order-get.md
@@ -50,7 +50,6 @@ Content-Type: application/json
         "language": "nb-NO",
         "urls" : { "id": "/psp/paymentorders/{{ page.payment_order_id }}/urls" },
         "payeeInfo" : { "id": "/psp/paymentorders/{{ page.payment_order_id }}/payeeinfo" },
-        "settings": { "id": "/psp/paymentorders/{{ page.payment_order_id }}/settings" },
         "payers": { "id": "/psp/paymentorders/{{ page.payment_order_id }}/payers" },
         "orderItems" : { "id": "/psp/paymentorders/{{ page.payment_order_id }}/orderItems" },
         "metadata": { "id": "/psp/paymentorders/{{ page.payment_order_id }}/metadata" },

--- a/_includes/update-payment-order.md
+++ b/_includes/update-payment-order.md
@@ -119,7 +119,6 @@ Content-Type: application/json
         "language": "nb-NO",
         "urls" : { "id": "/psp/paymentorders/{{ page.payment_order_id }}/urls" },
         "payeeInfo" : { "id": "/psp/paymentorders/{{ page.payment_order_id }}/payeeinfo" },
-        "settings": { "id": "/psp/paymentorders/{{ page.payment_order_id }}/settings" },
         "payers": { "id": "/psp/{{ api_resource }}/payments/{{ page.payment_id }}/payers"
         "orderItems" : { "id": "/psp/paymentorders/{{ page.payment_order_id }}/orderItems" },
         "metadata": { "id": "/psp/paymentorders/{{ page.payment_order_id }}/metadata" },


### PR DESCRIPTION
Removed the settings node from all the payment order responses I could find.