### PR TITLE
DX-969: Release tweaks

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -17,6 +17,7 @@ pull_request_rules:
   - name: Thank contributor
     conditions:
       - merged
+      - -author~=^.*\[bot\]$
     actions:
       comment:
         message: "Thank you @{{author}} for your contribution!"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,9 +1,12 @@
 name-template: '$RESOLVED_VERSION 🌈'
 tag-template: '$RESOLVED_VERSION'
 categories:
-  - title: '⬆️ Dependencies'
+  - title: '🖋 Documentation'
     labels:
-      - 'dependencies'
+      - 'documentation'
+  - title: '👩🏻‍💻 Development'
+    labels:
+      - 'development'
   - title: '🐛 Bug Fixes'
     labels:
       - 'fix'
@@ -13,12 +16,9 @@ categories:
   - title: '📝 Configuration'
     labels:
       - 'config'
-  - title: '👩🏻‍💻 Development'
+  - title: '⬆️ Dependencies'
     labels:
-      - 'development'
-  - title: '🖋 Documentation'
-    labels:
-      - 'documentation'
+      - 'dependencies'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,12 +1,10 @@
 name: Release PR
 
-on:
-  push:
-    branches:
-      - release/*
+on: create
 
 jobs:
   variables:
+    if: ${{ contains(github.ref, 'refs/heads/releases/') }}
     outputs:
       release: ${{ steps.variables.outputs.release }}
     runs-on: ubuntu-latest
@@ -18,6 +16,7 @@ jobs:
         run: .github/scripts/variables.sh
 
   release-develop-pr:
+    if: ${{ contains(github.ref, 'refs/heads/releases/') }}
     runs-on: ubuntu-latest
     needs: variables
     steps:
@@ -33,6 +32,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   release-master-pr:
+    if: ${{ contains(github.ref, 'refs/heads/releases/') }}
     runs-on: ubuntu-latest
     needs: variables
     steps:

--- a/_config.yml
+++ b/_config.yml
@@ -76,5 +76,4 @@ elasticsearch:
   index_name: test-psp-developer    # Optional. Default is "jekyll".
   default_type: post                # Optional. Default type is "post".
   environments:                     # Optional. Set environments where Searchyll should run
-    - production                    # Default runs on all environment if empty
     - stage                         # If set will only run in specified environments


### PR DESCRIPTION
Tweaks the release process a bit.

- The GitHub Action that creates pull requests for releases now only creates PR on the first `push` of the release branch. Subsequent pushes to the release branch should not incur new pull requests.
- Stop Mergify from thanking bots for their contributions.
- Reorder the headers in the description of releases so "Documentation" is placed on the top and "Dependencies" at the bottom.
- Searchyll should no longer index documents in production since [it is failing](https://github.com/SwedbankPay/developer.swedbankpay.com/runs/3241034364#step:3:215).