### PR TITLE
DX-1856 Add --overwrite flag

### DIFF
--- a/.github/workflows/azure-production.yml
+++ b/.github/workflows/azure-production.yml
@@ -29,4 +29,4 @@ jobs:
       - name: deploy
         uses: azure/CLI@v1.0.6
         with:
-          inlineScript: az storage blob upload-batch -s _site -d "\$web" --account-name blobdevportalprod
+          inlineScript: az storage blob upload-batch -s _site -d "\$web" --account-name blobdevportalprod --overwrite

--- a/.github/workflows/azure-stage.yml
+++ b/.github/workflows/azure-stage.yml
@@ -29,4 +29,4 @@ jobs:
       - name: deploy
         uses: azure/CLI@v1.0.6
         with:
-          inlineScript: az storage blob upload-batch -s _site -d "\$web" --account-name blobdevportalstage
+          inlineScript: az storage blob upload-batch -s _site -d "\$web" --account-name blobdevportalstage --overwrite


### PR DESCRIPTION
The deploy workflow is not able to upload the files due to an update for Azure cli ([az storage blob upload-batch returns ErrorCode:BlobAlreadyExists error v2.34.0 on upload · Issue #21477 · Azure/azure-cli](https://github.com/Azure/azure-cli/issues/21477) )
An `--overwrite` flag needs to be added.