### PR TITLE
DX-1933: Removing fees from basic payment order examples and making an optional feature

### DIFF
--- a/_includes/fee-discount.md
+++ b/_includes/fee-discount.md
@@ -1,0 +1,68 @@
+{% capture documentation_section %}{%- include documentation-section.md -%}{% endcapture %}
+{% capture features_url %}{% include documentation-section-url.md href='/features' %}{% endcapture %}
+
+## Fees And Discounts
+
+If you want to add fees or discounts to your payment order, this can be done by
+adding them as `orderItems` in your request. Use positive amounts for fees and
+negative amounts for discounts. Remember that the sum of the `orderItems` must
+match the total payment order amount.
+
+Restricting the fee or discount to certain instruments is also possible. Simply
+add the `restrictToInstruments` field and which instruments the fee or discount
+applies to. This is currently available for invoice only.
+
+The example below shows a fee which only applies to Swedish invoices. Other
+options for some of the fields are in the table at the bottom.
+
+## Fee Request
+
+{:.code-view-header}
+**Request**
+
+```http
+POST /psp/paymentorders HTTP/1.1
+Host: {{ page.api_host }}
+Authorization: Bearer <AccessToken>
+Content-Type: application/json
+
+     "orderItems": [
+            {
+                "reference": "I1",
+                "name": "InvoiceFee",
+                "type": "PAYMENT_FEE",
+                "class": "Fees",
+                "description": "Fee for paying with Invoice",
+                "quantity": 1,
+                "quantityUnit": "pcs",
+                "unitPrice": 1900,
+                "vatPercent": 0,
+                "amount": 1900,
+                "vatAmount": 0,
+                "restrictedToInstruments": [
+                    "Invoice-PayExFinancingSe"
+                ]
+            }
+        ]
+```
+
+{:.table .table-striped}
+| Field                    | Type         | Description                                                                                                                                                                                                               |
+| :----------------------- | :----------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| {% icon check %} | └➔&nbsp;`orderItems`               | `array`      | {% include field-description-orderitems.md %}                                                                                                                                                                                                                                                            |
+| {% icon check %} | └─➔&nbsp;`reference`               | `string`     | A reference that identifies the order item.                                                                                                                                                                                                                                                              |
+| {% icon check %} | └─➔&nbsp;`name`                    | `string`     | The name of the order item.                                                                                                                                                                                                                                                                              |
+| {% icon check %} | └─➔&nbsp;`type`                    | `string`     | `PRODUCT`, `SERVICE`, `SHIPPING_FEE`, `PAYMENT_FEE` `DISCOUNT`, `VALUE_CODE` or `OTHER`. The type of the order item. `PAYMENT_FEE` is the amount you are charged with when you are paying with invoice. The amount can be defined in the `amount` field below.                                           |
+| {% icon check %} | └─➔&nbsp;`class`                   | `string`     | The classification of the order item. Can be used for assigning the order item to a specific product category, such as `MobilePhone`. Note that `class` cannot contain spaces and must follow the regex pattern `[\w-]*`. Swedbank Pay may use this field for statistics.                                |
+|                  | └─➔&nbsp;`itemUrl`                 | `string`     | The URL to a page that can display the purchased item, product or similar.                                                                                                                                                                                                                               |
+|        ︎︎︎          | └─➔&nbsp;`imageUrl`                | `string`     | The URL to an image of the order item.                                                                                                                                                                                                                                                                    |
+|                  | └─➔&nbsp;`description`             | `string`     | {% include field-description-description.md %}                                                                                                                                                                                                                                                           |
+|                  | └─➔&nbsp;`discountDescription`     | `string`     | Used for discounts only. The human readable description of the possible discount.                                                                                                                                                                                                                                                 |
+| {% icon check %} | └─➔&nbsp;`quantity`                | `integer`    | The 4 decimal precision quantity of order items being purchased.                                                                                                                                                                                                                                         |
+| {% icon check %} | └─➔&nbsp;`quantityUnit`            | `string`     | The unit of the quantity, such as `pcs`, `grams`, or similar. This is used for your own book keeping.                                                                                                                                                                                                    |
+| {% icon check %} | └─➔&nbsp;`unitPrice`               | `integer`    | The price per unit of order item, including VAT.                                                                                                                                                                                                                                                         |
+|                  | └─➔&nbsp;`discountPrice`           | `integer`    | Used for discounts only. If the order item is purchased at a discounted price. This field should contain that price, including VAT.                                                                                                                                                                                               |
+| {% icon check %} | └─➔&nbsp;`vatPercent`              | `integer`    | The percent value of the VAT multiplied by 100, so `25%` becomes `2500`.                                                                                                                                                                                                                                 |
+| {% icon check %} | └─➔&nbsp;`amount`                  | `integer`    | {% include field-description-amount.md %}                                                                                                                                                                                                                                                                |
+| {% icon check %} | └─➔&nbsp;`vatAmount`               | `integer`    | {% include field-description-vatamount.md %}                                                     |
+|                  | └➔&nbsp;`restrictedToInstruments`  | `array`      | A list of the instruments you wish to restrict the payment to. Currently `Invoice` only. `Invoice` supports the subtypes `PayExFinancingNo`, `PayExFinancingSe` and `PayMonthlyInvoiceSe`, separated by a dash, e.g.; `Invoice-PayExFinancingNo`. The fee or discount applies to all instruments if a restriction is not included. Use of this field requires an agreement with Swedbank Pay.                                    |

--- a/_includes/payment-order-checkout-business.md
+++ b/_includes/payment-order-checkout-business.md
@@ -95,22 +95,6 @@ Content-Type: application/json
                 "vatPercent": 2500,
                 "amount": 1500,
                 "vatAmount": 375
-            },
-            {
-                "reference": "I1",
-                "name": "InvoiceFee",
-                "type": "PAYMENT_FEE",
-                "class": "Fees",
-                "description": "Fee for paying with Invoice",
-                "quantity": 1,
-                "quantityUnit": "pcs",
-                "unitPrice": 1900,
-                "vatPercent": 0,
-                "amount": 1900,
-                "vatAmount": 0,
-                "restrictedToInstruments": [
-                    "Invoice-PayExFinancingSe"
-                ]
             }
         ],
         "riskIndicator": {
@@ -207,7 +191,6 @@ Content-Type: application/json
 | {% icon check %} | └─➔&nbsp;`vatPercent`              | `integer`    | The percent value of the VAT multiplied by 100, so `25%` becomes `2500`.                                                                                                                                                                                                                                 |
 | {% icon check %} | └─➔&nbsp;`amount`                  | `integer`    | {% include field-description-amount.md %}                                                                                                                                                                                                                                                                |
 | {% icon check %} | └─➔&nbsp;`vatAmount`               | `integer`    | {% include field-description-vatamount.md %}                                                     |
-|                  | └➔&nbsp;`restrictedToInstruments`  | `array`      | A list of the instruments you wish to restrict the payment to. Currently `Invoice` only. `Invoice` supports the subtypes `PayExFinancingNo`, `PayExFinancingSe` and `PayMonthlyInvoiceSe`, separated by a dash, e.g.; `Invoice-PayExFinancingNo`. Default value is all supported payment instruments. Use of this field requires an agreement with Swedbank Pay. You can restrict fees and/or discounts to certain instruments by adding this field to the orderline you want to restrict. Use positive amounts to add fees and negative amounts to add discounts.                                                  |
 {% include risk-indicator-table.md %}
 
 ## Payment Order Response

--- a/_includes/payment-order-checkout-enterprise.md
+++ b/_includes/payment-order-checkout-enterprise.md
@@ -100,22 +100,6 @@ Content-Type: application/json
                 "vatPercent": 2500,
                 "amount": 1500,
                 "vatAmount": 375
-            },
-            {
-                "reference": "I1",
-                "name": "InvoiceFee",
-                "type": "PAYMENT_FEE",
-                "class": "Fees",
-                "description": "Fee for paying with Invoice",
-                "quantity": 1,
-                "quantityUnit": "pcs",
-                "unitPrice": 1900,
-                "vatPercent": 0,
-                "amount": 1900,
-                "vatAmount": 0,
-                "restrictedToInstruments": [
-                    "Invoice-PayExFinancingSe"
-                ]
             }
         ],
         "riskIndicator": {
@@ -216,7 +200,6 @@ Content-Type: application/json
 | {% icon check %} | └─➔&nbsp;`vatPercent`              | `integer`    | The percent value of the VAT multiplied by 100, so `25%` becomes `2500`.                                                                                                                                                                                                                                 |
 | {% icon check %} | └─➔&nbsp;`amount`                  | `integer`    | {% include field-description-amount.md %}                                                                                                                                                                                                                                                                |
 | {% icon check %} | └─➔&nbsp;`vatAmount`               | `integer`    | {% include field-description-vatamount.md %}                                                     |
-|                  | └➔&nbsp;`restrictedToInstruments`  | `array`      | A list of the instruments you wish to restrict the payment to. Currently `Invoice` only. `Invoice` supports the subtypes `PayExFinancingNo`, `PayExFinancingSe` and `PayMonthlyInvoiceSe`, separated by a dash, e.g.; `Invoice-PayExFinancingNo`. Default value is all supported payment instruments. Use of this field requires an agreement with Swedbank Pay. You can restrict fees and/or discounts to certain instruments by adding this field to the orderline you want to restrict. Use positive amounts to add fees and negative amounts to add discounts.                                                  |
 {% include risk-indicator-table.md %}
 
 ## Payment Order Response

--- a/_includes/payment-order-checkout-payments-only.md
+++ b/_includes/payment-order-checkout-payments-only.md
@@ -96,22 +96,6 @@ Content-Type: application/json
                 "vatPercent": 2500,
                 "amount": 1500,
                 "vatAmount": 375
-            },
-            {
-                "reference": "I1",
-                "name": "InvoiceFee",
-                "type": "PAYMENT_FEE",
-                "class": "Fees",
-                "description": "Fee for paying with Invoice",
-                "quantity": 1,
-                "quantityUnit": "pcs",
-                "unitPrice": 1900,
-                "vatPercent": 0,
-                "amount": 1900,
-                "vatAmount": 0,
-                "restrictedToInstruments": [
-                    "Invoice-PayExFinancingSe"
-                ]
             }
         ],
         "riskIndicator": {
@@ -209,7 +193,6 @@ Content-Type: application/json
 | {% icon check %} | └─➔&nbsp;`vatPercent`              | `integer`    | The percent value of the VAT multiplied by 100, so `25%` becomes `2500`.                                                                                                                                                                                                                                 |
 | {% icon check %} | └─➔&nbsp;`amount`                  | `integer`    | {% include field-description-amount.md %}                                                                                                                                                                                                                                                                |
 | {% icon check %} | └─➔&nbsp;`vatAmount`               | `integer`    | {% include field-description-vatamount.md %}                                                     |
-|                  | └➔&nbsp;`restrictedToInstruments`  | `array`      | A list of the instruments you wish to restrict the payment to. Currently `Invoice` only. `Invoice` supports the subtypes `PayExFinancingNo`, `PayExFinancingSe` and `PayMonthlyInvoiceSe`, separated by a dash, e.g.; `Invoice-PayExFinancingNo`. Default value is all supported payment instruments. Use of this field requires an agreement with Swedbank Pay. You can restrict fees and/or discounts to certain instruments by adding this field to the orderline you want to restrict. Use positive amounts to add fees and negative amounts to add discounts.                                                  |
 {% include risk-indicator-table.md %}
 
 ## Payment Order Response

--- a/_includes/payment-order-checkout-starter.md
+++ b/_includes/payment-order-checkout-starter.md
@@ -62,22 +62,6 @@ Content-Type: application/json
                 "vatPercent": 2500,
                 "amount": 1500,
                 "vatAmount": 375
-            },
-            {
-                "reference": "I1",
-                "name": "InvoiceFee",
-                "type": "PAYMENT_FEE",
-                "class": "Fees",
-                "description": "Fee for paying with Invoice",
-                "quantity": 1,
-                "quantityUnit": "pcs",
-                "unitPrice": 1900,
-                "vatPercent": 0,
-                "amount": 1900,
-                "vatAmount": 0,
-                "restrictedToInstruments": [
-                    "Invoice-PayExFinancingSe"
-                ]
             }
         ],
         "riskIndicator": {
@@ -148,7 +132,6 @@ Content-Type: application/json
 | {% icon check %} | └─➔&nbsp;`vatPercent`              | `integer`    | The percent value of the VAT multiplied by 100, so `25%` becomes `2500`.                                                                                                                                                                                                                                 |
 | {% icon check %} | └─➔&nbsp;`amount`                  | `integer`    | {% include field-description-amount.md %}                                                                                                                                                                                                                                                                |
 | {% icon check %} | └─➔&nbsp;`vatAmount`               | `integer`    | {% include field-description-vatamount.md %}                                                     |
-|                  | └➔&nbsp;`restrictedToInstruments`  | `array`      | A list of the instruments you wish to restrict the payment to. Currently `Invoice` only. `Invoice` supports the subtypes `PayExFinancingNo`, `PayExFinancingSe` and `PayMonthlyInvoiceSe`, separated by a dash, e.g.; `Invoice-PayExFinancingNo`. Default value is all supported payment instruments. Use of this field requires an agreement with Swedbank Pay. You can restrict fees and/or discounts to certain instruments by adding this field to the orderline you want to restrict. Use positive amounts to add fees and negative amounts to add discounts.                                                  |
 {% include risk-indicator-table.md %}
 
 ## Payment Order Response

--- a/_includes/payment-order-moto.md
+++ b/_includes/payment-order-moto.md
@@ -114,22 +114,6 @@ Content-Type: application/json
                 "vatPercent": 2500,
                 "amount": 1500,
                 "vatAmount": 375
-            },
-            {
-                "reference": "I1",
-                "name": "InvoiceFee",
-                "type": "PAYMENT_FEE",
-                "class": "Fees",
-                "description": "Fee for paying with Invoice",
-                "quantity": 1,
-                "quantityUnit": "pcs",
-                "unitPrice": 1900,
-                "vatPercent": 0,
-                "amount": 1900,
-                "vatAmount": 0,
-                "restrictedToInstruments": [
-                    "Invoice-PayExFinancingSe"
-                ]
             }
         ],
         "riskIndicator": {

--- a/_includes/payment-order-purchase.md
+++ b/_includes/payment-order-purchase.md
@@ -67,22 +67,6 @@ Content-Type: application/json
                 "vatPercent": 2500,
                 "amount": 1500,
                 "vatAmount": 375
-            },
-            {
-                "reference": "I1",
-                "name": "InvoiceFee",
-                "type": "PAYMENT_FEE",
-                "class": "Fees",
-                "description": "Fee for paying with Invoice",
-                "quantity": 1,
-                "quantityUnit": "pcs",
-                "unitPrice": 1900,
-                "vatPercent": 0,
-                "amount": 1900,
-                "vatAmount": 0,
-                "restrictedToInstruments": [
-                    "Invoice-PayExFinancingSe"
-                ]
             }
         ],
         "riskIndicator": {
@@ -250,7 +234,6 @@ Content-Type: application/json
 | {% icon check %} | └─➔&nbsp;`vatPercent`              | `integer`    | The percent value of the VAT multiplied by 100, so `25%` becomes `2500`.                                                                                                                                                                                                                                 |
 | {% icon check %} | └─➔&nbsp;`amount`                  | `integer`    | {% include field-description-amount.md %}                                                                                                                                                                                                                                                                |
 | {% icon check %} | └─➔&nbsp;`vatAmount`               | `integer`    | {% include field-description-vatamount.md %}                                                     |
-|                  | └➔&nbsp;`restrictedToInstruments`  | `array`      | A list of the instruments you wish to restrict the payment to. Currently `Invoice` only. `Invoice` supports the subtypes `PayExFinancingNo`, `PayExFinancingSe` and `PayMonthlyInvoiceSe`, separated by a dash, e.g.; `Invoice-PayExFinancingNo`. Default value is all supported payment instruments. Use of this field requires an agreement with Swedbank Pay. You can restrict fees and/or discounts to certain instruments by adding this field to the orderline you want to restrict. Use positive amounts to add fees and negative amounts to add discounts.                                                  |
 {% include risk-indicator-table.md %}
 
 {:.table .table-striped}

--- a/_includes/payment-order-recur.md
+++ b/_includes/payment-order-recur.md
@@ -119,22 +119,6 @@ Content-Type: application/json
                 "vatPercent": 2500,
                 "amount": 1500,
                 "vatAmount": 375
-            },
-            {
-                "reference": "I1",
-                "name": "InvoiceFee",
-                "type": "PAYMENT_FEE",
-                "class": "Fees",
-                "description": "Fee for paying with Invoice",
-                "quantity": 1,
-                "quantityUnit": "pcs",
-                "unitPrice": 1900,
-                "vatPercent": 0,
-                "amount": 1900,
-                "vatAmount": 0,
-                "restrictedToInstruments": [
-                    "Invoice-PayExFinancingSe"
-                ]
             }
         ],
         "riskIndicator": {
@@ -232,7 +216,6 @@ Content-Type: application/json
 | {% icon check %} | └─➔&nbsp;`vatPercent`              | `integer`    | The percent value of the VAT multiplied by 100, so `25%` becomes `2500`.                                                                                                                                                                                                                                 |
 | {% icon check %} | └─➔&nbsp;`amount`                  | `integer`    | {% include field-description-amount.md %}                                                                                                                                                                                                                                                                |
 | {% icon check %} | └─➔&nbsp;`vatAmount`               | `integer`    | {% include field-description-vatamount.md %}                                                     |
-|                  | └➔&nbsp;`restrictedToInstruments`  | `array`      | A list of the instruments you wish to restrict the payment to. Currently `Invoice` only. `Invoice` supports the subtypes `PayExFinancingNo`, `PayExFinancingSe` and `PayMonthlyInvoiceSe`, separated by a dash, e.g.; `Invoice-PayExFinancingNo`. Default value is all supported payment instruments. Use of this field requires an agreement with Swedbank Pay. You can restrict fees and/or discounts to certain instruments by adding this field to the orderline you want to restrict. Use positive amounts to add fees and negative amounts to add discounts.                                                  |
 {% include risk-indicator-table.md %}
 
 ## Initial Recur Response

--- a/_includes/payment-order-unscheduled.md
+++ b/_includes/payment-order-unscheduled.md
@@ -123,22 +123,6 @@ Content-Type: application/json
                 "vatPercent": 2500,
                 "amount": 1500,
                 "vatAmount": 375
-            },
-            {
-                "reference": "I1",
-                "name": "InvoiceFee",
-                "type": "PAYMENT_FEE",
-                "class": "Fees",
-                "description": "Fee for paying with Invoice",
-                "quantity": 1,
-                "quantityUnit": "pcs",
-                "unitPrice": 1900,
-                "vatPercent": 0,
-                "amount": 1900,
-                "vatAmount": 0,
-                "restrictedToInstruments": [
-                    "Invoice-PayExFinancingSe"
-                ]
             }
         ],
         "riskIndicator": {
@@ -236,7 +220,6 @@ Content-Type: application/json
 | {% icon check %} | └─➔&nbsp;`vatPercent`              | `integer`    | The percent value of the VAT multiplied by 100, so `25%` becomes `2500`.                                                                                                                                                                                                                                 |
 | {% icon check %} | └─➔&nbsp;`amount`                  | `integer`    | {% include field-description-amount.md %}                                                                                                                                                                                                                                                                |
 | {% icon check %} | └─➔&nbsp;`vatAmount`               | `integer`    | {% include field-description-vatamount.md %}                                                     |
-|                  | └➔&nbsp;`restrictedToInstruments`  | `array`      | A list of the instruments you wish to restrict the payment to. Currently `Invoice` only. `Invoice` supports the subtypes `PayExFinancingNo`, `PayExFinancingSe` and `PayMonthlyInvoiceSe`, separated by a dash, e.g.; `Invoice-PayExFinancingNo`. Default value is all supported payment instruments. Use of this field requires an agreement with Swedbank Pay. You can restrict fees and/or discounts to certain instruments by adding this field to the orderline you want to restrict. Use positive amounts to add fees and negative amounts to add discounts.                                                  |
 {% include risk-indicator-table.md %}
 
 ## Initial Unscheduled Response

--- a/checkout-v2/features/optional/fees-discounts.md
+++ b/checkout-v2/features/optional/fees-discounts.md
@@ -1,0 +1,12 @@
+---
+title: Fees And Discounts
+estimated_read: 2
+description: |
+  How to add fees and discounts to payment orders.
+menu_order: 1500
+icon:
+  content: discount
+  outlined: true
+---
+
+{% include fee-discount.md %}

--- a/checkout-v2/features/optional/mac.md
+++ b/checkout-v2/features/optional/mac.md
@@ -2,7 +2,7 @@
 title: Enterprise
 estimated_read: 3
 description: The Checkin alternative.
-menu_order: 1500
+menu_order: 1600
 icon:
   content: verified
   outlined: true

--- a/checkout-v2/features/optional/recur.md
+++ b/checkout-v2/features/optional/recur.md
@@ -2,7 +2,7 @@
 title: Recur
 estimated_read: 12
 description: Setting up subscriptions and recurring payments.
-menu_order: 1600
+menu_order: 1700
 icon:
   content: cached
   outlined: true

--- a/checkout-v2/features/optional/tra.md
+++ b/checkout-v2/features/optional/tra.md
@@ -2,7 +2,7 @@
 title: TRA Exemption
 estimated_read: 4
 description: Transaction Risk Analysis Exemption
-menu_order: 1700
+menu_order: 1800
 icon:
   content: verified
   outlined: true

--- a/checkout-v2/features/optional/unscheduled.md
+++ b/checkout-v2/features/optional/unscheduled.md
@@ -2,7 +2,7 @@
 title: Unscheduled Purchase
 estimated_read: 12
 description: Setting up subscriptions and merchant initiated payments.
-menu_order: 1800
+menu_order: 1900
 icon:
   content: report_problem
   outlined: true

--- a/checkout-v2/features/optional/update.md
+++ b/checkout-v2/features/optional/update.md
@@ -2,7 +2,7 @@
 title: Update Payment Order
 estimated_read: 5
 description: Updating the payment order
-menu_order: 1900
+menu_order: 2000
 icon:
   content: cached
   outlined: true

--- a/checkout-v2/features/optional/verify.md
+++ b/checkout-v2/features/optional/verify.md
@@ -2,7 +2,7 @@
 title: Verify
 estimated_read: 4
 description: Validating the payer's payment details.
-menu_order: 2000
+menu_order: 2100
 icon:
   content: verified_user
   outlined: true

--- a/checkout-v3/business/features/optional/fees-discounts.md
+++ b/checkout-v3/business/features/optional/fees-discounts.md
@@ -1,0 +1,12 @@
+---
+title: Fees And Discounts
+estimated_read: 2
+description: |
+  How to add fees and discounts to payment orders.
+menu_order: 1600
+icon:
+  content: discount
+  outlined: true
+---
+
+{% include fee-discount.md %}

--- a/checkout-v3/business/features/optional/instrument-mode.md
+++ b/checkout-v3/business/features/optional/instrument-mode.md
@@ -2,7 +2,7 @@
 title: Instrument Mode
 estimated_read: 30
 description: The Payment Menu with one payment instrument
-menu_order: 1600
+menu_order: 1700
 icon:
   content: looks_one
   outlined: true

--- a/checkout-v3/business/features/optional/recur.md
+++ b/checkout-v3/business/features/optional/recur.md
@@ -3,7 +3,7 @@ title: Recur
 estimated_read: 12
 description: |
   Setting up subscriptions and recurring payments.
-menu_order: 1700
+menu_order: 1800
 icon:
   content: cached
   outlined: true

--- a/checkout-v3/business/features/optional/request-delivery-info.md
+++ b/checkout-v3/business/features/optional/request-delivery-info.md
@@ -3,7 +3,7 @@ title: Request Delivery Information
 estimated_read: 2
 description: |
   Request that payment instruments return delivery information.
-menu_order: 1800
+menu_order: 1900
 icon:
   content: local_shipping
   outlined: true

--- a/checkout-v3/business/features/optional/transaction-on-file.md
+++ b/checkout-v3/business/features/optional/transaction-on-file.md
@@ -3,7 +3,7 @@ title: Transaction On File
 estimated_read: 4
 description: |
   Submitting subsequent transactions via file.
-menu_order: 1900
+menu_order: 2000
 icon:
   content: cached
   outlined: true

--- a/checkout-v3/business/features/optional/unscheduled.md
+++ b/checkout-v3/business/features/optional/unscheduled.md
@@ -3,7 +3,7 @@ title: Unscheduled Purchase
 estimated_read: 12
 description: |
   Setting up subscriptions and merchant initiated payments.
-menu_order: 2000
+menu_order: 2100
 icon:
   content: report_problem
   outlined: true

--- a/checkout-v3/business/features/optional/verify.md
+++ b/checkout-v3/business/features/optional/verify.md
@@ -3,7 +3,7 @@ title: Verify
 estimated_read: 4
 description: |
   Validating the payer's payment details.
-menu_order: 2100
+menu_order: 2200
 icon:
   content: verified_user
   outlined: true

--- a/checkout-v3/enterprise/features/optional/fees-discounts.md
+++ b/checkout-v3/enterprise/features/optional/fees-discounts.md
@@ -1,0 +1,12 @@
+---
+title: Fees And Discounts
+estimated_read: 2
+description: |
+  How to add fees and discounts to payment orders.
+menu_order: 1700
+icon:
+  content: discount
+  outlined: true
+---
+
+{% include fee-discount.md %}

--- a/checkout-v3/enterprise/features/optional/instrument-mode.md
+++ b/checkout-v3/enterprise/features/optional/instrument-mode.md
@@ -2,7 +2,7 @@
 title: Instrument Mode
 estimated_read: 30
 description: The Payment Menu with one payment instrument
-menu_order: 1700
+menu_order: 1800
 icon:
   content: looks_one
   outlined: true

--- a/checkout-v3/enterprise/features/optional/mac.md
+++ b/checkout-v3/enterprise/features/optional/mac.md
@@ -2,7 +2,7 @@
 title: Enterprise
 estimated_read: 3
 description: The Checkin alternative.
-menu_order: 1800
+menu_order: 1900
 icon:
   content: verified
   outlined: true

--- a/checkout-v3/enterprise/features/optional/recur.md
+++ b/checkout-v3/enterprise/features/optional/recur.md
@@ -3,7 +3,7 @@ title: Recur
 estimated_read: 12
 description: |
   Setting up subscriptions and recurring payments.
-menu_order: 1900
+menu_order: 2000
 icon:
   content: cached
   outlined: true

--- a/checkout-v3/enterprise/features/optional/request-delivery-info.md
+++ b/checkout-v3/enterprise/features/optional/request-delivery-info.md
@@ -3,7 +3,7 @@ title: Request Delivery Information
 estimated_read: 2
 description: |
   Request that payment instruments return delivery information.
-menu_order: 2000
+menu_order: 2100
 icon:
   content: local_shipping
   outlined: true

--- a/checkout-v3/enterprise/features/optional/tra.md
+++ b/checkout-v3/enterprise/features/optional/tra.md
@@ -2,7 +2,7 @@
 title: TRA Exemption
 estimated_read: 4
 description: Transaction Risk Analysis Exemption
-menu_order: 2100
+menu_order: 2200
 icon:
   content: verified
   outlined: true

--- a/checkout-v3/enterprise/features/optional/unscheduled.md
+++ b/checkout-v3/enterprise/features/optional/unscheduled.md
@@ -3,7 +3,7 @@ title: Unscheduled Purchase
 estimated_read: 12
 description: |
   Setting up subscriptions and merchant initiated payments.
-menu_order: 2200
+menu_order: 2300
 icon:
   content: report_problem
   outlined: true

--- a/checkout-v3/enterprise/features/optional/verify.md
+++ b/checkout-v3/enterprise/features/optional/verify.md
@@ -3,7 +3,7 @@ title: Verify
 estimated_read: 4
 description: |
   Validating the payer's payment details.
-menu_order: 2300
+menu_order: 2400
 icon:
   content: verified_user
   outlined: true

--- a/checkout-v3/payments-only/features/optional/fees-discounts.md
+++ b/checkout-v3/payments-only/features/optional/fees-discounts.md
@@ -1,0 +1,12 @@
+---
+title: Fees And Discounts
+estimated_read: 2
+description: |
+  How to add fees and discounts to payment orders.
+menu_order: 1600
+icon:
+  content: discount
+  outlined: true
+---
+
+{% include fee-discount.md %}

--- a/checkout-v3/payments-only/features/optional/instrument-mode.md
+++ b/checkout-v3/payments-only/features/optional/instrument-mode.md
@@ -2,7 +2,7 @@
 title: Instrument Mode
 estimated_read: 30
 description: The Payment Menu with one payment instrument
-menu_order: 1600
+menu_order: 1700
 icon:
   content: looks_one
   outlined: true

--- a/checkout-v3/payments-only/features/optional/moto.md
+++ b/checkout-v3/payments-only/features/optional/moto.md
@@ -3,7 +3,7 @@ title: MOTO
 estimated_read: 3
 description: |
   Mail Order / Telephone Order transactions.
-menu_order: 1700
+menu_order: 1800
 icon:
   content: dns
   outlined: true

--- a/checkout-v3/payments-only/features/optional/one-click-payments.md
+++ b/checkout-v3/payments-only/features/optional/one-click-payments.md
@@ -3,7 +3,7 @@ title: One-Click Payments
 estimated_read:  5
 description: |
   Prefilling the payment details using payment tokens.
-menu_order: 1800
+menu_order: 1900
 icon:
   content: touch_app
   outlined: true

--- a/checkout-v3/payments-only/features/optional/payer-aware-payment-menu.md
+++ b/checkout-v3/payments-only/features/optional/payer-aware-payment-menu.md
@@ -3,7 +3,7 @@ title: Payer Aware Payment Menu
 estimated_read: 4
 description: |
   A payment menu tailored to the payer.
-menu_order: 1900
+menu_order: 2000
 icon:
     content: event
     outlined: true

--- a/checkout-v3/payments-only/features/optional/recur.md
+++ b/checkout-v3/payments-only/features/optional/recur.md
@@ -3,7 +3,7 @@ title: Recur
 estimated_read: 12
 description: |
   Setting up subscriptions and recurring payments.
-menu_order: 2000
+menu_order: 2100
 icon:
   content: cached
   outlined: true

--- a/checkout-v3/payments-only/features/optional/request-delivery-info.md
+++ b/checkout-v3/payments-only/features/optional/request-delivery-info.md
@@ -3,7 +3,7 @@ title: Request Delivery Information
 estimated_read: 2
 description: |
   Request that payment instruments return delivery information.
-menu_order: 2100
+menu_order: 2200
 icon:
   content: local_shipping
   outlined: true

--- a/checkout-v3/payments-only/features/optional/unscheduled.md
+++ b/checkout-v3/payments-only/features/optional/unscheduled.md
@@ -3,7 +3,7 @@ title: Unscheduled Purchase
 estimated_read: 12
 description: |
   Setting up subscriptions and merchant initiated payments.
-menu_order: 2200
+menu_order: 2300
 icon:
   content: report_problem
   outlined: true

--- a/checkout-v3/payments-only/features/optional/verify.md
+++ b/checkout-v3/payments-only/features/optional/verify.md
@@ -3,7 +3,7 @@ title: Verify
 estimated_read: 4
 description: |
   Validating the payer's payment details.
-menu_order: 2300
+menu_order: 2400
 icon:
   content: verified_user
   outlined: true

--- a/checkout-v3/starter/features/optional/fees-discounts.md
+++ b/checkout-v3/starter/features/optional/fees-discounts.md
@@ -1,0 +1,12 @@
+---
+title: Fees And Discounts
+estimated_read: 2
+description: |
+  How to add fees and discounts to payment orders.
+menu_order: 1500
+icon:
+  content: discount
+  outlined: true
+---
+
+{% include fee-discount.md %}

--- a/checkout-v3/starter/features/optional/instrument-mode.md
+++ b/checkout-v3/starter/features/optional/instrument-mode.md
@@ -2,7 +2,7 @@
 title: Instrument Mode
 estimated_read: 30
 description: The Payment Menu with one payment instrument
-menu_order: 1500
+menu_order: 1600
 icon:
   content: looks_one
   outlined: true

--- a/checkout-v3/starter/features/optional/recur.md
+++ b/checkout-v3/starter/features/optional/recur.md
@@ -3,7 +3,7 @@ title: Recur
 estimated_read: 12
 description: |
   Setting up subscriptions and recurring payments.
-menu_order: 1600
+menu_order: 1700
 icon:
   content: cached
   outlined: true

--- a/checkout-v3/starter/features/optional/transaction-on-file.md
+++ b/checkout-v3/starter/features/optional/transaction-on-file.md
@@ -3,7 +3,7 @@ title: Transaction On File
 estimated_read: 4
 description: |
   Submitting subsequent transactions via file.
-menu_order: 1700
+menu_order: 1800
 icon:
   content: cached
   outlined: true

--- a/checkout-v3/starter/features/optional/unscheduled.md
+++ b/checkout-v3/starter/features/optional/unscheduled.md
@@ -3,7 +3,7 @@ title: Unscheduled Purchase
 estimated_read: 12
 description: |
   Setting up subscriptions and merchant initiated payments.
-menu_order: 1800
+menu_order: 1900
 icon:
   content: report_problem
   outlined: true

--- a/checkout-v3/starter/features/optional/verify.md
+++ b/checkout-v3/starter/features/optional/verify.md
@@ -3,7 +3,7 @@ title: Verify
 estimated_read: 4
 description: |
   Validating the payer's payment details.
-menu_order: 1900
+menu_order: 2000
 icon:
   content: verified_user
   outlined: true

--- a/payment-menu/features/optional/fees-discounts.md
+++ b/payment-menu/features/optional/fees-discounts.md
@@ -1,0 +1,12 @@
+---
+title: Fees And Discounts
+estimated_read: 2
+description: |
+  How to add fees and discounts to payment orders.
+menu_order: 1500
+icon:
+  content: discount
+  outlined: true
+---
+
+{% include fee-discount.md %}

--- a/payment-menu/features/optional/instrument-mode.md
+++ b/payment-menu/features/optional/instrument-mode.md
@@ -2,7 +2,7 @@
 title: Instrument Mode
 estimated_read: 30
 description: The Payment Menu with one payment instrument
-menu_order: 1500
+menu_order: 1600
 icon:
   content: looks_one
   outlined: true

--- a/payment-menu/features/optional/moto.md
+++ b/payment-menu/features/optional/moto.md
@@ -3,7 +3,7 @@ title: MOTO
 estimated_read: 3
 description: |
   Mail Order / Telephone Order transactions.
-menu_order: 1600
+menu_order: 1700
 icon:
   content: dns
   outlined: true

--- a/payment-menu/features/optional/one-click-payments.md
+++ b/payment-menu/features/optional/one-click-payments.md
@@ -3,7 +3,7 @@ title: One-Click Payments
 estimated_read:  5
 description: |
   Prefilling the payment details using payment tokens.
-menu_order: 1700
+menu_order: 1800
 icon:
   content: touch_app
   outlined: true

--- a/payment-menu/features/optional/payer-aware-payment-menu.md
+++ b/payment-menu/features/optional/payer-aware-payment-menu.md
@@ -3,7 +3,7 @@ title: Payer Aware Payment Menu
 estimated_read: 4
 description: |
   A payment menu tailored to the payer.
-menu_order: 1800
+menu_order: 1900
 icon:
     content: event
     outlined: true

--- a/payment-menu/features/optional/payment-link.md
+++ b/payment-menu/features/optional/payment-link.md
@@ -3,7 +3,7 @@ title: Payment Link
 estimated_read: 5
 description: |
   Sending the payment via mail or SMS.
-menu_order: 1900
+menu_order: 2000
 icon:
   content: link
   outlined: true

--- a/payment-menu/features/optional/payment-order-update.md
+++ b/payment-menu/features/optional/payment-order-update.md
@@ -3,7 +3,7 @@ title: Update Payment Order
 estimated_read: 5
 description: |
   Updating the payment order
-menu_order: 2300
+menu_order: 2400
 icon:
   content: cached
   outlined: true

--- a/payment-menu/features/optional/recur.md
+++ b/payment-menu/features/optional/recur.md
@@ -3,7 +3,7 @@ title: Recur
 estimated_read: 12
 description: |
   Setting up subscriptions and recurring payments.
-menu_order: 2000
+menu_order: 2100
 icon:
   content: cached
   outlined: true

--- a/payment-menu/features/optional/transaction-on-file.md
+++ b/payment-menu/features/optional/transaction-on-file.md
@@ -3,7 +3,7 @@ title: Transaction On File
 estimated_read: 4
 description: |
   Submitting subsequent transactions via file.
-menu_order: 2100
+menu_order: 2200
 icon:
   content: cached
   outlined: true

--- a/payment-menu/features/optional/unscheduled.md
+++ b/payment-menu/features/optional/unscheduled.md
@@ -3,7 +3,7 @@ title: Unscheduled Purchase
 estimated_read: 12
 description: |
   Setting up subscriptions and merchant-initiated payments.
-menu_order: 2200
+menu_order: 2300
 icon:
   content: report_problem
   outlined: true


### PR DESCRIPTION
Added the feature to all payment order places. The feature section might need additional work, but is not worse than what was already there. Fiddling more about on this now is not a priority.