### PR TITLE
Release 3.1.4 (develop)

### DIFF
--- a/resources/release-notes.md
+++ b/resources/release-notes.md
@@ -11,6 +11,17 @@ menu_order: 800
 body="The version numbers used in headers on this page refers to the version of
 this very documentation, not to a version of any APIs described by it." %}
 
+## 18 October 2022
+
+### Version 3.1.4
+
+Even with an autumn break (with Swedbank Pay colors everywhere you look), there
+are two important ones this time around. We now offer **Click to Pay** for both
+Redirect and Seamless View in all four [Checkout v3][checkout-v3]
+implementations.  We have also added a new capability called
+[Cross Channel Payments][cross-channel-payments], which we hope you read!
+Apart from that, there are no releases without typo corrections and bug fixes.
+
 ## 20 September 2022
 
 ### Version 3.1.3
@@ -707,6 +718,7 @@ integration and the payer.
 [checkout-items]: /checkout-v2/features/technical-reference/items
 [checkout-3ds2]: /checkout-v2/features/core/3d-secure-2
 [checkout-callback]: /checkout-v2/features/core/callback
+[checkout-v3]: /checkout-v3/
 [checkout-v3-business]: /checkout-v3/business
 [checkout-v3-payments-only-redirect-request]: /checkout-v3/payments-only/redirect#payment-order-request
 [checkout-v3-payments-only-seamless]: /checkout-v3/payments-only/seamless-view
@@ -715,6 +727,7 @@ integration and the payer.
 [core-features]: /checkout-v2/features/core/
 [credit-card-abort]: /payment-instruments/card/after-payment#abort
 [credit]: /payment-instruments/card
+[cross-channel-payments]: /checkout-v3/payments-only/features/optional/cross-channel-payments
 [data-protection]: /resources/data-protection
 [delete-payment-tokens]: /checkout-v3/payments-only/features/optional/delete-token#delete-paymenttoken-request
 [demoshop]: https://ecom.externalintegration.payex.com/pspdemoshop


### PR DESCRIPTION
## 18 October 2022

### Version 3.1.4

Even with an autumn break (with Swedbank Pay colors everywhere you look), there are two big ones this time around. We now offer **Click to Pay** for both Redirect and Seamless View in all four Checkout v3 implementations.  We have also added a new capability called Cross Channel Payments, which we hope you read up on! Apart from that, there are no releases without typo corrections and bug fixes.