### PR TITLE
DX-1953: Removed requireConsumerInfo from Starter

### DIFF
--- a/_includes/payment-order-checkout-starter.md
+++ b/_includes/payment-order-checkout-starter.md
@@ -40,7 +40,6 @@ Content-Type: application/json
             "siteId": "MySiteId"
         },
         "payer": {
-            "requireConsumerInfo": true,
             "digitalProducts": false,
             "shippingAddressRestrictedToCountryCodes": [ "NO", "US" ]
         },
@@ -114,7 +113,6 @@ Content-Type: application/json
 |  {% icon check %} | └➔&nbsp;`payer`                    | `object`     | The `payer` object containing information about the payer relevant for the payment order.                                                                                                                                                                                                                |
 | | └➔&nbsp;`digitalProducts`                       | `bool` | Set to `true` for merchants who only sell digital goods and only require `email` and/or `msisdn` as shipping details. Set to `false` if the merchant also sells physical goods. |
 |                  | `shippingAddressRestrictedToCountryCodes` | `string` | List of supported shipping countries for merchant. Using [ISO-3166] standard. Mandatory if `digitalProducts` is set to `false`, and not to be included if it is `true`.                                    |
-|  {% icon check %} | `requireConsumerInfo` | `string` | Must be set to `true` by merchants using Starter, as they receive profile information from Swedbank Pay. This applies both when the merchant needs `email` and/or `msisdn` for digital goods, and when full shipping address is needed.                             |
 | {% icon check %} | └➔&nbsp;`orderItems`               | `array`      | {% include field-description-orderitems.md %}                                 |
 | {% icon check %} | └─➔&nbsp;`reference`               | `string`     | A reference that identifies the order item.                                                                                                                                                                                                                                                              |
 | {% icon check %} | └─➔&nbsp;`name`                    | `string`     | The name of the order item.                                                                                                                                                                                                                                                                              |

--- a/checkout-v3/starter/introduction.md
+++ b/checkout-v3/starter/introduction.md
@@ -10,8 +10,7 @@ This is the option where Swedbank Pay does it all. Verifying your consumer,
 collecting billing and shipping addresses, storing consumer information and
 providing you with the full range of available payment methods.
 
-The only way of integrating our **Starter** implementation is **Seamless
-View**.
+The only way of integrating our **Starter** implementation is **Seamless View**.
 
 With **Seamless View**, the payer stays at your site, and you initiate the
 Swedbank Pay authentication and purchase module in an iframe. The checkin and

--- a/checkout-v3/starter/seamless-view.md
+++ b/checkout-v3/starter/seamless-view.md
@@ -31,10 +31,8 @@ You can find it in the `paymentorder` field. This is required if you want to use
 Checkout v3. If it isn´t included in your request, you won't get the correct
 operations in the response.
 
-When `productName` is set to `checkout3`, `requireConsumerInfo` and
-`digitalProducts` will be set to `false` by default. For the **Starter**
-integration, you must set `requireConsumerInfo` to `true`. If `digitalProducts`
-is set to `false`, you also need to add
+When `productName` is set to `checkout3`, `digitalProducts` will be set to
+`false` by default. If `digitalProducts` is set to `false`, you also need to add
 `shippingAddressRestrictedToCountryCodes` along with ISO standard country codes.
 
 Supported features for this integration are subscriptions (`recur` and
@@ -249,7 +247,7 @@ open the payment menu. The payer can then proceed with the purchase.
 Once a purchase is complete, you can perform a `GET` towards the `paymentOrders`
 resource to see the purchase state.
 
-### Events
+## Events
 
 When integrating Seamless View, especially with **Starter** where it's the only
 option, we strongly recommend that you implement the `onPaid` event, as it will


### PR DESCRIPTION
Removed requireConsumerInfo as requested by Øyvind K, as it is deprecated.