### PR TITLE
DX-1996: HTTP QUERY support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :jekyll_plugins do
   gem 'jemoji'
   gem 'kramdown', '>= 2.3'
   gem 'kramdown-plantuml', '>= 1.3'
+  gem 'rouge', '>= 4.0.1'
   gem 'searchyll', git: 'https://github.com/SwedbankPay/searchyll.git'
   gem 'swedbank-pay-design-guide-jekyll-theme', '1.16.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,7 @@ DEPENDENCIES
   kramdown (>= 2.3)
   kramdown-plantuml (>= 1.3)
   rake (>= 13)
+  rouge (>= 4.0.1)
   rspec (>= 3)
   rubocop (>= 1)
   rubocop-rake (>= 0.6)

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ title: Developer Portal
 layout: front-page
 front_page:
   ingress: |
-We've compiled a complete toolbox for integrating our payment solutions, so you can familiarize yourself with their various features and functionalities.
+    We've compiled a complete toolbox for integrating our payment solutions, so you can familiarize yourself with their various features and functionalities.
   show_merchants_bar: false
   start_heading: Let's get your e-commerce website up and running with easy, flexible, and safe payments!
 hide_from_sidebar: true


### PR DESCRIPTION
Explicitly adds the `rouge` Gem version `4.0.1` so we are certain the latest version is used, as doesn't seem to be the case after #1666. Also adds missing indentation to `index.md` to fix the blank front-page.