### PR TITLE
DX-2028: Set RubyGems version to 3.3.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
+          rubygems: 3.3.22
           bundler-cache: true
       - name: Cache HTMLProofer
         id: cache-htmlproofer


### PR DESCRIPTION
Set RubyGems explicitly to version `3.3.22` to avoid [these kinds of build errors](https://github.com/SwedbankPay/developer.swedbankpay.com/actions/runs/4014043509/jobs/6894150855).