### PR TITLE
Release 3.1.8 (develop)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :jekyll_plugins do
   gem 'kramdown-plantuml', '>= 1.3'
   gem 'rouge', '>= 4.0.1'
   gem 'searchyll', git: 'https://github.com/SwedbankPay/searchyll.git'
-  gem 'swedbank-pay-design-guide-jekyll-theme', '2.0.0'
+  gem 'swedbank-pay-design-guide-jekyll-theme', '1.16.2'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    swedbank-pay-design-guide-jekyll-theme (2.0.0)
+    swedbank-pay-design-guide-jekyll-theme (1.16.2)
       faraday (>= 1.0.1, < 3)
       jekyll (>= 3.7, < 5.0)
       jekyll-contentblocks (~> 1, >= 1.2)
@@ -200,7 +200,7 @@ DEPENDENCIES
   rubocop (>= 1)
   rubocop-rake (>= 0.6)
   searchyll!
-  swedbank-pay-design-guide-jekyll-theme (= 2.0.0)
+  swedbank-pay-design-guide-jekyll-theme (= 1.16.2)
 
 RUBY VERSION
    ruby 2.7.6p219

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       jekyll-redirect-from (~> 0.16)
       jemoji (~> 0.12)
       kramdown-plantuml (~> 1, >= 1.3.2)
-      nokogiri (~> 1.11)
+      nokogiri (~> 1, >= 1.11)
       sass (~> 3, >= 3.7)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)

--- a/resources/release-notes.md
+++ b/resources/release-notes.md
@@ -11,6 +11,17 @@ menu_order: 800
 body="The version numbers used in headers on this page refers to the version of
 this very documentation, not to a version of any APIs described by it." %}
 
+## 31 January 2023
+
+### Version 3.1.8
+
+Bigger things are coming up around the bend, so we are stopping by with some
+smaller fixes and a [Checkout v3 matrix][checkout-v3-matrix] giving you a better
+overview over which payment instruments v3 has to offer, and the countries they
+are available.
+
+We'll be back soon!
+
 ## 17 January 2023
 
 ### Version 3.1.7
@@ -750,6 +761,7 @@ integration and the payer.
 [checkout-callback]: /checkout-v2/features/core/callback
 [checkout-v3-business]: /checkout-v3/business
 [checkout-v3-business-payment-request]: /checkout-v3/business/redirect#payment-order-request
+[checkout-v3-matrix]: /checkout-v3/#choose-the-right-implementation-for-your-business
 [checkout-v3-payments-only-redirect-request]: /checkout-v3/payments-only/redirect#payment-order-request
 [checkout-v3-payments-only-seamless]: /checkout-v3/payments-only/seamless-view
 [checkout-v3-starter]: /checkout-v3/starter


### PR DESCRIPTION
## 31 January 2023

### Version 3.1.8

Bigger things are coming up around the bend, so we are stopping by with some smaller fixes and a Checkout v3 matrix giving you a better overview over which payment instruments v3 has to offer, and the countries they are available.

We'll be back soon!