### PR TITLE
DX-2028: Downgrade theme from 2.0.0 to 1.16.2

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,9 +1,3 @@
-queue_rules:
-  - name: default
-    conditions:
-      # Conditions to get out of the queue (= merged)
-      - check-success=build
-
 pull_request_rules:
   - name: Automatic approve on dependabot PR
     conditions:
@@ -15,10 +9,14 @@ pull_request_rules:
   - name: Automatic merge on approval
     conditions:
       - author~=^dependabot(|-preview)\[bot\]$
+      - '#commits-behind=0' # Only merge up to date pull requests
+      - check-success=license/cla
+      - check-success=shellcheck
+      - check-success=variables
+      - check-success=build
+      - check-success=spec
     actions:
-      queue:
-        method: merge
-        name: default
+      merge:
 
   - name: Thank contributor
     conditions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,6 +15,7 @@ pull_request_rules:
       - check-success=variables
       - check-success=build
       - check-success=spec
+      - "-body~=swedbank-pay-design-guide-jekyll-theme" # Don't merge if the PR contains the string "swedbank-pay-design-guide-jekyll-theme"
     actions:
       merge:
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :jekyll_plugins do
   gem 'kramdown-plantuml', '>= 1.3'
   gem 'rouge', '>= 4.0.1'
   gem 'searchyll', git: 'https://github.com/SwedbankPay/searchyll.git'
-  gem 'swedbank-pay-design-guide-jekyll-theme', '2.0.0'
+  gem 'swedbank-pay-design-guide-jekyll-theme', '1.16.2'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    swedbank-pay-design-guide-jekyll-theme (2.0.0)
+    swedbank-pay-design-guide-jekyll-theme (1.16.2)
       faraday (>= 1.0.1, < 3)
       jekyll (>= 3.7, < 5.0)
       jekyll-contentblocks (~> 1, >= 1.2)
@@ -165,7 +165,7 @@ GEM
       jekyll-redirect-from (~> 0.16)
       jemoji (~> 0.12)
       kramdown-plantuml (~> 1, >= 1.3.2)
-      nokogiri (~> 1.11)
+      nokogiri (~> 1, >= 1.11)
       sass (~> 3, >= 3.7)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -200,7 +200,7 @@ DEPENDENCIES
   rubocop (>= 1)
   rubocop-rake (>= 0.6)
   searchyll!
-  swedbank-pay-design-guide-jekyll-theme (= 2.0.0)
+  swedbank-pay-design-guide-jekyll-theme (= 1.16.2)
 
 RUBY VERSION
    ruby 2.7.6p219


### PR DESCRIPTION
Downgrade theme from version 2.0.0 to version 1.16.2. Again! With https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1708#issuecomment-1411797979, there's hope it will stay ignored this time.

Reverts #1708.