### PR TITLE
Release 4.1.0 (develop)

### DIFF
--- a/resources/release-notes.md
+++ b/resources/release-notes.md
@@ -10,6 +10,18 @@ menu_order: 800
 body="The version numbers used in headers on this page refers to the version of
 this very documentation, not to a version of any APIs described by it." %}
 
+## 10 March 2023
+
+### Version 4.1.0
+
+A lot of changes are happening these days. We've made the decision to focus the
+Checkout v3 offering, so our Starter and Business implementations are no more.
+This means that we can do what we do best: giving you a payment experience
+packed with options. The [Payments Only][checkout-v3-payments-only]
+implementation is still here, and for those of you with a Strong Consumer
+Authentication who want access to our safely stored card data,
+[Enterprise][checkout-v3-enterprise] is still available too.
+
 ## 03 March 2023
 
 ### Version 4.0.0
@@ -777,6 +789,8 @@ integration and the payer.
 [checkout-3ds2]: /checkout-v2/features/core/3d-secure-2
 [checkout-callback]: /checkout-v2/features/core/callback
 [checkout-v3-matrix]: /checkout-v3/#choose-the-right-implementation-for-your-business
+checkout-v3-enterprise]: /checkout-v3/enterprise
+[checkout-v3-payments-only]: /checkout-v3/payments-only
 [checkout-v3-payments-only-redirect-request]: /checkout-v3/payments-only/redirect#payment-order-request
 [checkout-v3-payments-only-seamless]: /checkout-v3/payments-only/seamless-view
 [click-to-pay]: /checkout-v3/payment-presentations#click-to-pay

--- a/resources/release-notes.md
+++ b/resources/release-notes.md
@@ -789,7 +789,7 @@ integration and the payer.
 [checkout-3ds2]: /checkout-v2/features/core/3d-secure-2
 [checkout-callback]: /checkout-v2/features/core/callback
 [checkout-v3-matrix]: /checkout-v3/#choose-the-right-implementation-for-your-business
-checkout-v3-enterprise]: /checkout-v3/enterprise
+[checkout-v3-enterprise]: /checkout-v3/enterprise
 [checkout-v3-payments-only]: /checkout-v3/payments-only
 [checkout-v3-payments-only-redirect-request]: /checkout-v3/payments-only/redirect#payment-order-request
 [checkout-v3-payments-only-seamless]: /checkout-v3/payments-only/seamless-view


### PR DESCRIPTION
Version 4.1.0

A lot of changes are happening these days. We've made the decision to focus the Checkout v3 offering, so our Starter and Business implementations are no more. This means that we can do what we do best: giving you a payment experience packed with options. The Payments Only implementation is still here, and for those of you with a Strong Consumer Authentication who want access to our safely stored card data, Enterprise is still available too.

Changes

🖋 Documentation

DX-2072: Small amount correction after feedback @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1748)
DX-2069: Removed Verify options for recurrenceTokens @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1747)
DX-2031: Updated quantity field from integer to number @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1744)
DX-2015: Re-introduced the brown headers. @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1743)
DX-2051: Hide starter and business from portal @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1741)
Release 4.0.0 (develop) @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1740)
👩🏻‍💻 Development

DX-2071: Updated theme to 2.1.6 @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1746)
Bump npm from 9.6.0 to 9.6.1 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1745)
⬆️ Dependencies

Bump npm from 9.6.0 to 9.6.1 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1745)
Bump rubocop from 1.47.0 to 1.48.0 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1742)