### PR TITLE
Release 4.2.0 (develop)

### DIFF
--- a/resources/release-notes.md
+++ b/resources/release-notes.md
@@ -832,7 +832,7 @@ integration and the payer.
 [mobilepay-capture]: /old-implementations/payment-instruments-v1/mobile-pay/capture
 [modules-sdks]: /modules-sdks
 [moto-payment-card]: /old-implementations/payment-instruments-v1/card/features/optional/moto
-[old-implementations]: old-implementations/
+[old-implementations]: /old-implementations/
 [one-click]: /old-implementations/payment-instruments-v1/card/features/optional/one-click-payments
 [optional-features]: /old-implementations/checkout-v2/features/optional/
 [payment-orders]: /old-implementations/checkout-v2/payment-menu#step-3-create-payment-order

--- a/resources/release-notes.md
+++ b/resources/release-notes.md
@@ -10,6 +10,16 @@ menu_order: 800
 body="The version numbers used in headers on this page refers to the version of
 this very documentation, not to a version of any APIs described by it." %}
 
+## 24 April 2023
+
+### Version 4.2.0
+
+The keen observer might spot some changes in our menu. The Checkout v2, Payment
+Menu and Payment Instruments have been moved to
+[Old Implementations][old-implementations]. You can still find everything you
+want and need, so no need to worry. A new [.NET SDK][pax-net-sdk] section has
+also been added, in addition to the usual bugs and small fixes.
+
 ## 10 March 2023
 
 ### Version 4.1.0
@@ -822,6 +832,7 @@ integration and the payer.
 [mobilepay-capture]: /old-implementations/payment-instruments-v1/mobile-pay/capture
 [modules-sdks]: /modules-sdks
 [moto-payment-card]: /old-implementations/payment-instruments-v1/card/features/optional/moto
+[old-implementations]: old-implementations/
 [one-click]: /old-implementations/payment-instruments-v1/card/features/optional/one-click-payments
 [optional-features]: /old-implementations/checkout-v2/features/optional/
 [payment-orders]: /old-implementations/checkout-v2/payment-menu#step-3-create-payment-order
@@ -831,6 +842,7 @@ integration and the payer.
 [payment-menu-payment-link]: /old-implementations/payment-menu-v2/features/optional/payment-link
 [payments]: /old-implementations/payment-instruments-v1/
 [payer-aware-payment-menu]: /checkout-v3/payments-only/features/optional/payer-aware-payment-menu
+[pax-net-sdk]: https://developer.stage.swedbankpay.com/modules-sdks/pax-terminal/instore-solution/NET/
 [prices]: /old-implementations/checkout-v2/features/technical-reference/prices
 [update-order-checkout]: /old-implementations/checkout-v2/features/optional/update
 [recur]: /checkout-v3/payments-only/features/optional/recur


### PR DESCRIPTION
24 April 2023

Version 4.2.0

The keen observer might spot some changes in our menu. The Checkout v2, Payment Menu and Payment Instruments have been moved to Old Implementations. You can still find everything you want and need, so no need to worry. A new .NET SDK section has also been added, in addition to the usual bugs and small fixes.

Documentation

DX-2093: Added Credit Account Disclaimer @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1773)
DX-2084: Removed including - from payeereference @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1772)
DX-2092: Replaced paymentorder with paymentOrder @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1771)
Pax terminal net section @the-anders-jarold (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1757)
DX-2067: Removed Starter and Business completely. Part one. @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1770)
Feature/dx 2038 create section for old implementations @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1756)
DX-2075: Remove payout from card @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1753)
Hotfix/dx 2090 fix apple pay domain file again (develop) @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1766)
Hotfix/dx 2090 fix apple pay domain file again (master) @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1765)
DX-2089 Hotfix Add new applePay domain file (develop) @sigridbra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1764)
DX-2089 Hotfix Add new applePay domain file (master) @sigridbra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1763)
DX-2074: Add Corporate Limited Menu to Checkout v3 Payments Only @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1751)
Release 4.1.0 (develop) @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1750)
👩🏻‍💻 Development

Bump npm from 9.6.4 to 9.6.5 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1769)
Bump npm from 9.6.3 to 9.6.4 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1760)
Bump npm from 9.6.1 to 9.6.3 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1758)
🐛 Bug Fixes

Hotfix/dx 2090 fix apple pay domain file again (develop) @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1766)
Hotfix/dx 2090 fix apple pay domain file again (master) @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1765)
⬆️ Dependencies

Bump npm from 9.6.4 to 9.6.5 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1769)
Bump rubocop from 1.50.1 to 1.50.2 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1768)
Bump rubocop from 1.50.0 to 1.50.1 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1767)
Bump nokogiri from 1.14.2 to 1.14.3 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1762)
Bump rubocop from 1.49.0 to 1.50.0 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1761)
Bump npm from 9.6.3 to 9.6.4 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1760)
Bump rubocop from 1.48.1 to 1.49.0 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1759)
Bump npm from 9.6.1 to 9.6.3 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1758)
Bump activesupport from 7.0.4.2 to 7.0.4.3 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1754)
Bump rubocop from 1.48.0 to 1.48.1 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/1752)