### PR TITLE
DX-2101: Remove introduction

### DIFF
--- a/_includes/callback.md
+++ b/_includes/callback.md
@@ -130,4 +130,4 @@ sequenceDiagram
     deactivate SwedbankPay
 ```
 
-[url-usage]: /introduction#url-usage
+[url-usage]: /resources/fundamental-principles#url-usage

--- a/_includes/fields/id.md
+++ b/_includes/fields/id.md
@@ -8,8 +8,8 @@
 {%- capture text -%}
     The relative URL and unique identifier of the
     `{{ resource }}` resource {{ sub_resource_text }}.
-    Please read about [URL Usage](/introduction#url-usage) to
-    understand how this and other URLs should be used in your solution.
+    Please read about [URL Usage](/resources/fundamental-principles#url-usage)
+    to understand how this and other URLs should be used in your solution.
 {%- endcapture -%}
 {%- comment -%}
 The following chain of Liquid filters converts newlines to spaces and removes

--- a/_includes/fields/initiating-system-user-agent.md
+++ b/_includes/fields/initiating-system-user-agent.md
@@ -4,7 +4,7 @@
     {%- assign api_resource = "Payment Order" -%}
 {%- endif -%}
 {%- capture initiating_system_user_agent -%}
-The [user agent](/introduction#user-agent) of the HTTP client making the
+The [user agent](/checkout-v3/payments-only/features/technical-reference/user-agent) of the HTTP client making the
 request, reflecting the value sent in the `User-Agent` header with the initial
 `POST` request which created the {{ api_resource | strip }}.
 {%- endcapture -%}

--- a/_includes/fields/payee-reference.md
+++ b/_includes/fields/payee-reference.md
@@ -8,7 +8,7 @@
 {% endif %}
 {%- capture payee_reference_url -%}
     {%- if documentation_section == nil or documentation_section == empty -%}
-        {%- assign payee_reference_url = "/introduction#payee-reference" -%}
+        {%- assign payee_reference_url = "/resources/fundamental-principles#payee-reference" -%}
     {%- else -%}
         {%- include utils/documentation-section-url.md href="/features/technical-reference/payee-reference" -%}
     {%- endif -%}

--- a/_includes/fields/user-agent.md
+++ b/_includes/fields/user-agent.md
@@ -1,6 +1,7 @@
 {%- capture user_agent -%}
-The [user agent](/introduction#user-agent) of the payer. Should typically be set
-to the value of the `User-Agent` header sent by the payer's web browser.
+The [user agent](/checkout-v3/payments-only/features/technical-reference/user-agent)
+of the payer. Should typically be set to the value of the `User-Agent` header
+sent by the payer's web browser.
 {%- endcapture -%}
 {%- comment -%}
 The following chain of Liquid filters converts newlines to spaces and removes

--- a/_includes/mobile-sdk-papm.md
+++ b/_includes/mobile-sdk-papm.md
@@ -243,4 +243,4 @@ paymentOrder.disableStoredPaymentDetails = true
 
 [add-stored-details]: /old-implementations/payment-menu-v2/features/optional/payer-aware-payment-menu#add-stored-payment-instrument-details
 [enterprise-payer-ref]: https://developer.swedbankpay.com/checkout-v3/enterprise/features/optional/enterprise-payer-reference
-[expanding_properties]: https://developer.swedbankpay.com/introduction#expansion
+[expanding_properties]: https://developer.swedbankpay.com/resources/fundamental-principles#expansion

--- a/_includes/mobile-sdk-tokens.md
+++ b/_includes/mobile-sdk-tokens.md
@@ -72,6 +72,6 @@ More info on [unscheduled purchases][unscheduled].
 
 More info on [recurring purchases][recur].
 
-[expanding_properties]: https://developer.swedbankpay.com/introduction#expansion
+[expanding_properties]: https://developer.swedbankpay.com/resources/fundamental-principles#expansion
 [unscheduled]: https://developer.swedbankpay.com/checkout-v3/payments-only/features/optional/unscheduled
 [recur]: https://developer.swedbankpay.com/checkout-v3/payments-only/features/optional/recur

--- a/_includes/transaction-response.md
+++ b/_includes/transaction-response.md
@@ -2,7 +2,7 @@
 {% capture documentation_section %}{% include utils/documentation-section.md %}{% endcapture %}
 {%- capture operations_href -%}
     {%- if documentation_section == nil or documentation_section == empty -%}
-        /introduction#operations
+        /resources/fundamental-principles#operations
     {%- else -%}
         {%- include utils/documentation-section-url.md href='/features/technical-reference/operations' -%}
     {%- endif -%}

--- a/_includes/user-agent.md
+++ b/_includes/user-agent.md
@@ -40,3 +40,5 @@ illustrated in the below sequence diagram:
     response JSON field.
 
 The user agent strings are used for statistical purposes by Swedbank Pay.
+
+[user-agent]: https://en.wikipedia.org/wiki/User_agent

--- a/_includes/user-agent.md
+++ b/_includes/user-agent.md
@@ -1,0 +1,42 @@
+## User-Agent
+
+The term [user agent][user-agent] is used for both the web browser used by the
+payer as well as the system making HTTP requests towards Swedbank Pay's APIs.
+The difference between these two and how they relate to each other is
+illustrated in the below sequence diagram:
+
+```plantuml
+@startuml "User Agents"
+    $participant("payer", "Payer") as Payer
+    $participant("merchant", "Merchant") as Merchant
+    $participant("server", "Swedbank Pay") as SwedbankPay
+
+    Payer -> Merchant: $code("User-Agent: P") <b>①</b>
+    activate Payer
+        activate SwedbankPay
+            Merchant -> SwedbankPay: $code('User-Agent: M { userAgent: "P" }') <b>②</b>
+            activate Merchant
+                SwedbankPay --> SwedbankPay: Store request data
+                SwedbankPay --> Merchant: $code('{ "initiatingSystemUserAgent": "M" }') <b>③</b>
+            deactivate Merchant
+        deactivate SwedbankPay
+        Merchant --> Payer
+    deactivate Payer
+@enduml
+```
+
+1.  First, the payer makes an HTTP request with their web browser towards the
+    merchant's website. This HTTP request contains a `User-Agent` header, here
+    given the value **`P`** (for "Payer").
+2.  The merchant performs an HTTP request towards Swedbank Pay.
+    1.  The merchant extracts the **`P`** value of the `User-Agent` header from
+      the payer's browser and sends it to Swedbank Pay in the `userAgent` field
+      in the JSON request body.
+    2.  The merchant also composes its own user agent string and sends it to
+      Swedbank Pay in the `User-Agent` HTTP request header, here represented as
+      the value **`M`** (for "Merchant").
+3.  Swedbank Pay receives `"userAgent": "P"` and `User-Agent: M`, stores the
+    values and returns the **`M`** value in the `initiatingSystemUserAgent`
+    response JSON field.
+
+The user agent strings are used for statistical purposes by Swedbank Pay.

--- a/checkout-v3/enterprise/features/technical-reference/user-agent.md
+++ b/checkout-v3/enterprise/features/technical-reference/user-agent.md
@@ -1,0 +1,10 @@
+---
+title: User Agent
+description: An introduction to user agents
+menu_order: 2800
+icon:
+  content: devices
+  outlined: true
+---
+
+{% include user-agent.md %}

--- a/checkout-v3/index.md
+++ b/checkout-v3/index.md
@@ -5,7 +5,7 @@ title: Get Started
 description: |
   **This page aims to provide you with a brief introduction to our two options
   for implementing our checkout in a way that makes sense for your business.**
-menu_order: 2
+menu_order: 1
 
 header:
   - table_header: Data Ownership

--- a/checkout-v3/payments-only/features/technical-reference/user-agent.md
+++ b/checkout-v3/payments-only/features/technical-reference/user-agent.md
@@ -1,0 +1,10 @@
+---
+title: User Agent
+description: An introduction to user agents
+menu_order: 2800
+icon:
+  content: devices
+  outlined: true
+---
+
+{% include user-agent.md %}

--- a/gift-cards/index.md
+++ b/gift-cards/index.md
@@ -3,7 +3,7 @@ section: Gift Cards
 sidebar_icon: redeem
 title: Introduction
 permalink: /:path/
-menu_order: 4
+menu_order: 3
 ---
 
 ## Overview

--- a/modules-sdks/index.md
+++ b/modules-sdks/index.md
@@ -7,7 +7,7 @@ description: |
   We have multiple Open Source-based SDKs and Modules to use with
   Swedbank Pay APIs.
 permalink: /:path/
-menu_order: 5
+menu_order: 4
 ---
 
 Swedbank Pay offers APIs, SDKs, libraries, modules, extensions and plugins as

--- a/modules-sdks/mobile-sdk/android.md
+++ b/modules-sdks/mobile-sdk/android.md
@@ -439,7 +439,7 @@ using the browser for third-party sites, please file a bug on the Android SDK.
 [dokka-problem-exception-problem]: https://github.com/SwedbankPay/swedbank-pay-sdk-android/blob/dev/sdk/dokka_github/sdk/com.swedbankpay.mobilesdk/
 [dokka-unexpected-exception]: https://github.com/SwedbankPay/swedbank-pay-sdk-android/blob/dev/sdk/dokka_github/sdk/com.swedbankpay.mobilesdk/
 [rfc-7807]: https://tools.ietf.org/html/rfc7807
-[swedbankpay-problems]: /introduction#problems
+[swedbankpay-problems]: /resources/fundamental-principles#problems
 [backend-problems]: merchant-backend#problems
 [dokka-problem]: https://github.com/SwedbankPay/swedbank-pay-sdk-android/blob/dev/sdk/dokka_github/sdk/com.swedbankpay.mobilesdk.merchantbackend/-merchant-backend-problem/index.md
 [dokka-problem-client]: https://github.com/SwedbankPay/swedbank-pay-sdk-android/blob/dev/sdk/dokka_github/sdk/com.swedbankpay.mobilesdk.merchantbackend/-merchant-backend-problem/-client/index.md

--- a/modules-sdks/mobile-sdk/android.md
+++ b/modules-sdks/mobile-sdk/android.md
@@ -439,7 +439,7 @@ using the browser for third-party sites, please file a bug on the Android SDK.
 [dokka-problem-exception-problem]: https://github.com/SwedbankPay/swedbank-pay-sdk-android/blob/dev/sdk/dokka_github/sdk/com.swedbankpay.mobilesdk/
 [dokka-unexpected-exception]: https://github.com/SwedbankPay/swedbank-pay-sdk-android/blob/dev/sdk/dokka_github/sdk/com.swedbankpay.mobilesdk/
 [rfc-7807]: https://tools.ietf.org/html/rfc7807
-[swedbankpay-problems]: /resources/fundamental-principles#problems
+[swedbankpay-problems]: /checkout-v3/payments-only/features/technical-reference/problems
 [backend-problems]: merchant-backend#problems
 [dokka-problem]: https://github.com/SwedbankPay/swedbank-pay-sdk-android/blob/dev/sdk/dokka_github/sdk/com.swedbankpay.mobilesdk.merchantbackend/-merchant-backend-problem/index.md
 [dokka-problem-client]: https://github.com/SwedbankPay/swedbank-pay-sdk-android/blob/dev/sdk/dokka_github/sdk/com.swedbankpay.mobilesdk.merchantbackend/-merchant-backend-problem/-client/index.md

--- a/modules-sdks/mobile-sdk/index.md
+++ b/modules-sdks/mobile-sdk/index.md
@@ -73,5 +73,5 @@ follow for each step.
 [checkout]: /checkout-v3
 [checkout-enterprise]: /checkout-v3/enterprise
 [checkout-payments-only]: /checkout-v3/payments-only
-[https]: /introduction#connection-and-protocol
+[https]: /resources/fundamental-principles#connection-and-protocol
 [post-purchase-capture]: /checkout-v3/payments-only/post-purchase#capture

--- a/modules-sdks/mobile-sdk/ios.md
+++ b/modules-sdks/mobile-sdk/ios.md
@@ -641,7 +641,7 @@ sequenceDiagram
 [xcode-add-cap]: https://help.apple.com/xcode/mac/current/#/dev88ff319e7
 [xcode-add-assoc-domain]: https://developer.apple.com/documentation/safariservices/supporting_associated_domains_in_your_app#3001207
 [rfc-7807]: https://tools.ietf.org/html/rfc7807
-[swedbankpay-problems]: /introduction#problems
+[swedbankpay-problems]: /resources/fundamental-principles#problems
 [backend-problems]: merchant-backend#problems
 [checkin-consumer]: /old-implementations/checkout-v2/checkin#step-1-initiate-session-for-consumer-identification
 [checkin-paymentorder]: /old-implementations/checkout-v2/payment-menu#step-3-create-payment-order

--- a/modules-sdks/mobile-sdk/ios.md
+++ b/modules-sdks/mobile-sdk/ios.md
@@ -641,7 +641,7 @@ sequenceDiagram
 [xcode-add-cap]: https://help.apple.com/xcode/mac/current/#/dev88ff319e7
 [xcode-add-assoc-domain]: https://developer.apple.com/documentation/safariservices/supporting_associated_domains_in_your_app#3001207
 [rfc-7807]: https://tools.ietf.org/html/rfc7807
-[swedbankpay-problems]: /resources/fundamental-principles#problems
+[swedbankpay-problems]: /checkout-v3/payments-only/features/technical-reference/problems
 [backend-problems]: merchant-backend#problems
 [checkin-consumer]: /old-implementations/checkout-v2/checkin#step-1-initiate-session-for-consumer-identification
 [checkin-paymentorder]: /old-implementations/checkout-v2/payment-menu#step-3-create-payment-order

--- a/modules-sdks/mobile-sdk/merchant-backend-v2.md
+++ b/modules-sdks/mobile-sdk/merchant-backend-v2.md
@@ -814,5 +814,5 @@ Your implementation is encouraged to define its own problem types for any domain
 [ios-universal-links-routing]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content#3001753
 [ios-aasa]: https://developer.apple.com/documentation/safariservices/supporting_associated_domains_in_your_app#3001215
 [rfc-7807]: https://tools.ietf.org/html/rfc7807
-[swedbankpay-problems]: /introduction#problems
+[swedbankpay-problems]: /resources/fundamental-principles#problems
 [instrument-mode]: /old-implementations/payment-menu-v2/features/optional/instrument-mode

--- a/modules-sdks/mobile-sdk/merchant-backend-v2.md
+++ b/modules-sdks/mobile-sdk/merchant-backend-v2.md
@@ -814,5 +814,5 @@ Your implementation is encouraged to define its own problem types for any domain
 [ios-universal-links-routing]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content#3001753
 [ios-aasa]: https://developer.apple.com/documentation/safariservices/supporting_associated_domains_in_your_app#3001215
 [rfc-7807]: https://tools.ietf.org/html/rfc7807
-[swedbankpay-problems]: /resources/fundamental-principles#problems
+[swedbankpay-problems]: /checkout-v3/payments-only/features/technical-reference/problems
 [instrument-mode]: /old-implementations/payment-menu-v2/features/optional/instrument-mode

--- a/modules-sdks/mobile-sdk/merchant-backend.md
+++ b/modules-sdks/mobile-sdk/merchant-backend.md
@@ -700,5 +700,5 @@ name under your control – usually the host name of the Merchant Backend.
 [ios-universal-links-routing]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content#3001753
 [ios-aasa]: https://developer.apple.com/documentation/safariservices/supporting_associated_domains_in_your_app#3001215
 [rfc-7807]: https://tools.ietf.org/html/rfc7807
-[swedbankpay-problems]: /resources/fundamental-principles#problems
+[swedbankpay-problems]: /checkout-v3/payments-only/features/technical-reference/problems
 [instrument-mode]: /old-implementations/payment-menu-v2/features/optional/instrument-mode

--- a/modules-sdks/mobile-sdk/merchant-backend.md
+++ b/modules-sdks/mobile-sdk/merchant-backend.md
@@ -700,5 +700,5 @@ name under your control – usually the host name of the Merchant Backend.
 [ios-universal-links-routing]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content#3001753
 [ios-aasa]: https://developer.apple.com/documentation/safariservices/supporting_associated_domains_in_your_app#3001215
 [rfc-7807]: https://tools.ietf.org/html/rfc7807
-[swedbankpay-problems]: /introduction#problems
+[swedbankpay-problems]: /resources/fundamental-principles#problems
 [instrument-mode]: /old-implementations/payment-menu-v2/features/optional/instrument-mode

--- a/old-implementations/checkout-v2/features/technical-reference/user-agent.md
+++ b/old-implementations/checkout-v2/features/technical-reference/user-agent.md
@@ -1,0 +1,10 @@
+---
+title: User Agent
+description: An introduction to user agents
+menu_order: 3600
+icon:
+  content: devices
+  outlined: true
+---
+
+{% include user-agent.md %}

--- a/old-implementations/checkout-v2/index.md
+++ b/old-implementations/checkout-v2/index.md
@@ -246,4 +246,4 @@ Norwegian `nb-NO` and Swedish `sv-SE`.
 
 [after-payment-capture]: /old-implementations/checkout-v2/capture
 [callback]: /old-implementations/checkout-v2/features/core/callback
-[https]: /introduction#connection-and-protocol
+[https]: /resources/fundamental-principles#connection-and-protocol

--- a/old-implementations/index.md
+++ b/old-implementations/index.md
@@ -4,7 +4,7 @@ sidebar_icon: folder
 title: Introduction
 description: |
   A collection of our earlier implementation options.
-menu_order: 3
+menu_order: 2
 ---
 
 If you are a **new merchant** getting started with your implementation,

--- a/old-implementations/payment-instruments-v1/card/features/technical-reference/user-agent.md
+++ b/old-implementations/payment-instruments-v1/card/features/technical-reference/user-agent.md
@@ -1,0 +1,10 @@
+---
+title: User Agent
+description: An introduction to user agents
+menu_order: 3200
+icon:
+  content: devices
+  outlined: true
+---
+
+{% include user-agent.md %}

--- a/old-implementations/payment-instruments-v1/index.md
+++ b/old-implementations/payment-instruments-v1/index.md
@@ -146,7 +146,7 @@ Please visit our [demoshop][demoshop] to see Payment Menu v2 and Payment
 Instruments v1 in action.
 
 [demoshop]: {{ page.front_end_url }}/pspdemoshop
-[https]: /introduction#connection-and-protocol
+[https]: /resources/fundamental-principles#connection-and-protocol
 [vipps-logo]: /assets/img/icon-vipps-simple.svg
 [swish-logo]: /assets/img/icon-swish-simple.svg
 [mobilepay-logo]: /assets/img/icon-mobilepay-simple.svg

--- a/old-implementations/payment-instruments-v1/invoice/features/technical-reference/user-agent.md
+++ b/old-implementations/payment-instruments-v1/invoice/features/technical-reference/user-agent.md
@@ -1,0 +1,10 @@
+---
+title: User Agent
+description: An introduction to user agents
+menu_order: 3400
+icon:
+  content: devices
+  outlined: true
+---
+
+{% include user-agent.md %}

--- a/old-implementations/payment-instruments-v1/mobile-pay/features/technical-reference/user-agent.md
+++ b/old-implementations/payment-instruments-v1/mobile-pay/features/technical-reference/user-agent.md
@@ -1,0 +1,10 @@
+---
+title: User Agent
+description: An introduction to user agents
+menu_order: 2800
+icon:
+  content: devices
+  outlined: true
+---
+
+{% include user-agent.md %}

--- a/old-implementations/payment-instruments-v1/swish/features/technical-reference/user-agent.md
+++ b/old-implementations/payment-instruments-v1/swish/features/technical-reference/user-agent.md
@@ -1,0 +1,10 @@
+---
+title: User Agent
+description: An introduction to user agents
+menu_order: 3000
+icon:
+  content: devices
+  outlined: true
+---
+
+{% include user-agent.md %}

--- a/old-implementations/payment-instruments-v1/trustly/features/technical-reference/user-agent.md
+++ b/old-implementations/payment-instruments-v1/trustly/features/technical-reference/user-agent.md
@@ -1,0 +1,10 @@
+---
+title: User Agent
+description: An introduction to user agents
+menu_order: 3100
+icon:
+  content: devices
+  outlined: true
+---
+
+{% include user-agent.md %}

--- a/old-implementations/payment-instruments-v1/vipps/after-payment.md
+++ b/old-implementations/payment-instruments-v1/vipps/after-payment.md
@@ -346,5 +346,5 @@ Content-Type: application/json
 [abort]: /old-implementations/payment-instruments-v1/vipps/after-payment#abort
 [cancel]: #cancellations
 [capture]: /old-implementations/payment-instruments-v1/vipps/features/core//capture
-[expand-parameter]: /introduction#expansion
+[expand-parameter]: /resources/fundamental-principles#expansion
 [reverse]: #reversals

--- a/old-implementations/payment-instruments-v1/vipps/features/technical-reference/user-agent.md
+++ b/old-implementations/payment-instruments-v1/vipps/features/technical-reference/user-agent.md
@@ -1,0 +1,10 @@
+---
+title: User Agent
+description: An introduction to user agents
+menu_order: 3300
+icon:
+  content: devices
+  outlined: true
+---
+
+{% include user-agent.md %}

--- a/old-implementations/payment-menu-v2/features/technical-reference/user-agent.md
+++ b/old-implementations/payment-menu-v2/features/technical-reference/user-agent.md
@@ -1,0 +1,10 @@
+---
+title: User Agent
+description: An introduction to user agents
+menu_order: 3500
+icon:
+  content: devices
+  outlined: true
+---
+
+{% include user-agent.md %}

--- a/old-implementations/payment-menu-v2/index.md
+++ b/old-implementations/payment-menu-v2/index.md
@@ -36,4 +36,4 @@ you have Swedbank Pay Payment Menu v2.
                          next_title="Payment Order" %}
 
 [after-payment-capture]: /old-implementations/payment-menu-v2/capture
-[https]: /introduction#connection-and-protocol
+[https]: /resources/fundamental-principles#connection-and-protocol

--- a/old-implementations/payment-menu-v2/payment-order.md
+++ b/old-implementations/payment-menu-v2/payment-order.md
@@ -63,7 +63,7 @@ in your system to look up status on the completed payment later.
 
 {% include alert.html type="informative" icon="info" header="URL Storage"
 body="The `id` of the Payment Order should be stored for later retrieval. [Read
-more about URL usage](/introduction#url-usage)." %}
+more about URL usage](/resources/fundamental-principles#url-usage)." %}
 
 Then find the `view-paymentorder` operation and embed its `href` in a `<script>`
 element. That script will then load the Seamless View for the Payment Menu. We

--- a/resources/data-protection.md
+++ b/resources/data-protection.md
@@ -1,6 +1,6 @@
 ---
 title: Data Protection
-menu_order: 1200
+menu_order: 700
 ---
 
 ## Paymentorder consumer data

--- a/resources/demoshop.md
+++ b/resources/demoshop.md
@@ -1,9 +1,0 @@
----
-title: Demoshop
-menu_order: 900
----
-
-{% include jumbotron.html body=
-"We are working on a brand new demoshop for you!
-In the meantime, knock yourself out with our existing
-[demoshop](https://ecom.externalintegration.payex.com/pspdemoshop)" %}

--- a/resources/development-guidelines/code-of-conduct.md
+++ b/resources/development-guidelines/code-of-conduct.md
@@ -1,6 +1,6 @@
 ---
 title: Code Of Conduct
-menu_order: 1300
+menu_order: 900
 ---
 
 <!--alex disable sexual attacks-->

--- a/resources/development-guidelines/contributing.md
+++ b/resources/development-guidelines/contributing.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-menu_order: 1400
+menu_order: 1000
 ---
 
 To make it clear exactly how outside contributors should provide their

--- a/resources/development-guidelines/good-commit-practice.md
+++ b/resources/development-guidelines/good-commit-practice.md
@@ -1,6 +1,6 @@
 ---
 title: Good Commit Practice
-menu_order: 1600
+menu_order: 1100
 ---
 
 The following document is a fork of

--- a/resources/development-guidelines/index.md
+++ b/resources/development-guidelines/index.md
@@ -2,7 +2,7 @@
 section: Open Source Development Guidelines
 title: Introduction
 permalink: /:path/
-menu_order: 1200
+menu_order: 800
 ---
 
 Swedbank Pay is committed to creating a vibrant community around its open

--- a/resources/development-guidelines/license.md
+++ b/resources/development-guidelines/license.md
@@ -1,6 +1,6 @@
 ---
 title: License
-menu_order: 1700
+menu_order: 1200
 ---
 
 ## Licensing

--- a/resources/fundamental-principles.md
+++ b/resources/fundamental-principles.md
@@ -1,7 +1,6 @@
 ---
-title: Introduction
-sidebar_icon: waving_hand
-menu_order: 1
+title: Fundamental Principles
+menu_order: 900
 description: |
     Read on to learn about the fundamentals and common architectural principles
     of the Swedbank Pay API Platform.
@@ -71,49 +70,6 @@ Forwarded: for=82.115.151.177; host=example.com; proto=https
 | {% icon check %}︎ | **`Accept`**        | The [content type][content-type] accepted by the client. Usually set to `application/json` and `application/problem+json` so both regular responses as well as errors can be received properly.                                                                                |
 |                  | **`Session-Id`**    | A trace identifier used to trace calls through the API Platform (ref [RFC 7329][rfc-7329]). Each request must mint a new [GUID/UUID][uuid]. If no `Session-Id` is provided, Swedbank Pay will generate one for the request.                                                    |
 |                  | **`Forwarded`**     | The IP address of the payer as well as the host and protocol of the payer-facing web page. When the header is present, only the `for` parameter containing the payer's IP address is required, the other parameters are optional. See [RFC 7239][rfc-7239] for details. |
-
-### User-Agent
-
-The term [user agent][user-agent] is used for both the web browser used by the
-payer as well as the system making HTTP requests towards Swedbank Pay's APIs.
-The difference between these two and how they relate to each other is
-illustrated in the below sequence diagram:
-
-```plantuml
-@startuml "User Agents"
-    $participant("payer", "Payer") as Payer
-    $participant("merchant", "Merchant") as Merchant
-    $participant("server", "Swedbank Pay") as SwedbankPay
-
-    Payer -> Merchant: $code("User-Agent: P") <b>①</b>
-    activate Payer
-        activate SwedbankPay
-            Merchant -> SwedbankPay: $code('User-Agent: M { userAgent: "P" }') <b>②</b>
-            activate Merchant
-                SwedbankPay --> SwedbankPay: Store request data
-                SwedbankPay --> Merchant: $code('{ "initiatingSystemUserAgent": "M" }') <b>③</b>
-            deactivate Merchant
-        deactivate SwedbankPay
-        Merchant --> Payer
-    deactivate Payer
-@enduml
-```
-
-1.  First, the payer makes an HTTP request with their web browser towards the
-    merchant's website. This HTTP request contains a `User-Agent` header, here
-    given the value **`P`** (for "Payer").
-2.  The merchant performs an HTTP request towards Swedbank Pay.
-    1.  The merchant extracts the **`P`** value of the `User-Agent` header from
-      the payer's browser and sends it to Swedbank Pay in the `userAgent` field
-      in the JSON request body.
-    2.  The merchant also composes its own user agent string and sends it to
-      Swedbank Pay in the `User-Agent` HTTP request header, here represented as
-      the value **`M`** (for "Merchant").
-3.  Swedbank Pay receives `"userAgent": "P"` and `User-Agent: M`, stores the
-    values and returns the **`M`** value in the `initiatingSystemUserAgent`
-    response JSON field.
-
-The user agent strings are used for statistical purposes by Swedbank Pay.
 
 ## URL Usage
 

--- a/resources/fundamental-principles.md
+++ b/resources/fundamental-principles.md
@@ -290,7 +290,6 @@ amount is multiplied by 100.
 [rfc-7329]: https://tools.ietf.org/html/rfc7329
 [robustness-principle]: https://en.wikipedia.org/wiki/Robustness_principle
 [ruby-tls]: https://stackoverflow.com/a/11059873/61818
-[settlement]: /old-implementations/payment-instruments-v1/invoice/features/core/settlement-reconciliation
 [ssllabs]: https://www.ssllabs.com/ssltest/analyze.html?d=api.payex.com
 [the-rest-and-then-some]: https://www.youtube.com/watch?v=QIv9YR1bMwY
 [user-agent]: https://en.wikipedia.org/wiki/User_agent

--- a/resources/fundamental-principles.md
+++ b/resources/fundamental-principles.md
@@ -273,67 +273,6 @@ amount is multiplied by 100.
 |   SEK 50.00 |      `5000` |
 |     € 10.00 |      `1000` |
 
-## Operations
-
-When a resource is created and during its lifetime, it will have a set of
-operations that can be performed on it. Which operations that are available
-in a given state varies depending on payment instrument used, what the access
-token is authorized to do, etc. A subset of possible operations are described
-below. Visit the technical reference page of a payment instrument for
-instrument specific operations.
-
-{:.code-view-header}
-**JSON with Operations**
-
-```json
-{
-    "payment": {},
-    "operations": [
-        {
-            "href": "http://{{ page.api_host }}/psp/creditcard/payments/{{ page.payment_id }}",
-            "rel": "update-payment-abort",
-            "method": "PATCH"
-        },
-        {
-            "href": "{{ page.front_end_url }}/creditcard/payments/authorize/{{ page.payment_token }}",
-            "rel": "redirect-authorization",
-            "method": "GET"
-        },
-        {
-            "href": "{{ page.front_end_url }}/swish/core/scripts/client/px.swish.client.js?token={{ page.payment_token }}",
-            "rel": "view-payment",
-            "method": "GET",
-            "contentType": "application/javascript"
-        },
-        {
-            "href": "{{ page.api_url }}/psp/creditcard/payments/{{ page.payment_id }}/captures",
-            "rel": "create-capture",
-            "method": "POST"
-        }
-    ]
-}
-```
-
-{:.table .table-striped}
-| Field    | Description                                                         |
-| :------- | :------------------------------------------------------------------ |
-| `href`   | The target URL to perform the operation against.                    |
-| `rel`    | The name of the relation the operation has to the current resource. |
-| `method` | The HTTP method to use when performing the operation.               |
-
-**The operations should be performed as described in each response and not as
-described here in the documentation**. Always use the `href` and `method` as
-specified in the response by finding the appropriate operation based on its
-`rel` value.
-
-{% include payee-reference.md %}
-
-[Read more about the settlement process here][settlement].
-
-{% include callback.md %}
-
-{% include problems/problems.md %}
-
 [admin]: https://merchantportal.externalintegration.swedbankpay.com
 [content-type]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
 [iso-3166]: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2

--- a/resources/index.md
+++ b/resources/index.md
@@ -6,7 +6,7 @@ description: |
   In this section you find various **resources** for Swedbank Pay's API
   Platform.
 permalink: /:path/
-menu_order: 6
+menu_order: 5
 ---
 
 ## Test Data

--- a/resources/index.md
+++ b/resources/index.md
@@ -9,23 +9,13 @@ permalink: /:path/
 menu_order: 5
 ---
 
-## Test Data
-
-To perform tests of the Swedbank Pay API platform, [test data][test-data] is
-required to perform various actions in our interfaces, such as in Checkin,
-performing payments, etc.
-
-## Demoshop
-
-Our [Demoshop][demoshop] provides a good demonstration of how our services work
-and which functionality they provide in a realistic webshop.
-
-## Open Source Development Guidelines
-
-All Open Source Software that is developed in Swedbank Pay's name, and under our
-control, including this very Developer Portal, must adhere to a set of
-[guidelines][guidelines].
+A small library of tools that might come in handy on your journey through our
+Developer Portal, from [test data][test-data],
+[developer guidelines][guidelines], [public migration key][pmk] to
+[terminology][terminology] and a list of our [partners][partners].
 
 [test-data]: test-data
-[demoshop]: demoshop
 [guidelines]: development-guidelines
+[pmk]: public-migration-key
+[terminology]: terminology
+[partners]: partners

--- a/resources/partners.md
+++ b/resources/partners.md
@@ -1,6 +1,6 @@
 ---
 title: Partners
-menu_order: 7
+menu_order: 1000
 sidebar_icon: handshake
 description: |
     We have a lot of partners who help us create the best payment experience.

--- a/resources/public-migration-key.md
+++ b/resources/public-migration-key.md
@@ -5,7 +5,7 @@ description: |
   our **Public Migration Key** to encrypt the data in transmission.
   Contact our support at [support.ecom@payex.com](mailto:support.ecom@payex.com)
   for more information regarding this procedure.
-menu_order: 1300
+menu_order: 1100
 ---
 
 *   **Key size**: 4096 bits

--- a/resources/release-notes.md
+++ b/resources/release-notes.md
@@ -861,7 +861,7 @@ integration and the payer.
 [status-models]: /checkout-v3/payments-only/features/technical-reference/status-models
 [status-model-paid]: /checkout-v3/payments-only/features/technical-reference/status-models#paid
 [status-model-paid-v2]: /old-implementations/checkout-v2/features/technical-reference/status-models#paid
-[storing-uri]: /introduction#storing-urls
+[storing-uri]: /resources/fundamental-principles#storing-urls
 [swish-api-errors]: /old-implementations/payment-instruments-v1/swish/features/technical-reference/problems
 [swish-direct-mcom]: /old-implementations/payment-instruments-v1/swish/direct#step-2b-create-m-commerce-sale-transaction
 [swish-direct]: /old-implementations/payment-instruments-v1/swish/direct

--- a/resources/release-notes.md
+++ b/resources/release-notes.md
@@ -3,7 +3,7 @@ title: Release Notes
 description: |
   The latest updates about our releases will be
   published on this page.
-menu_order: 800
+menu_order: 1200
 ---
 
 {% include alert.html type="informative" icon="info" header="Version numbers"

--- a/resources/release-notes.md
+++ b/resources/release-notes.md
@@ -819,7 +819,7 @@ integration and the payer.
 [get-started]: /checkout-v3/
 [gift-cards]: /gift-cards
 [google-pay]: /checkout-v3/payment-presentations#google-pay
-[home-technical-information]: /introduction
+[home-technical-information]: /resources/fundamental-principles
 [initiate-consumer-session]: /old-implementations/checkout-v2/checkin#step-1-initiate-session-for-consumer-identification
 [invoice-direct]: /old-implementations/payment-instruments-v1/invoice/direct
 [invoice]: /old-implementations/payment-instruments-v1/invoice

--- a/resources/terminology.md
+++ b/resources/terminology.md
@@ -98,10 +98,10 @@ menu_order: 1100
 [callback-url]:/old-implementations/payment-instruments-v1/card/features/core/callback
 [cancel-url]: /old-implementations/payment-instruments-v1/card/after-payment#cancellations
 [checkout-url]: /checkout-v3
-[common-headers]: /introduction#headers
+[common-headers]: /resources/fundamental-principles#headers
 [fundamentals]: /old-implementations/payment-instruments-v1/#the-fundamentals
 [hateoas]: https://en.wikipedia.org/wiki/HATEOAS
 [invoice-url]: /old-implementations/payment-instruments-v1/invoice/
 [recur]: /old-implementations/payment-instruments-v1/card/features/optional/recur
-[restful-api]: /introduction#connection-and-protocol
+[restful-api]: /resources/fundamental-principles#connection-and-protocol
 [verify-url]: /old-implementations/payment-instruments-v1/card/features/optional/verify

--- a/resources/test-data.md
+++ b/resources/test-data.md
@@ -3,7 +3,7 @@ title: Test Data
 description: |
   Testing, are we? Good! Here's some data you can
   use to test and verify your integration!
-menu_order: 1000
+menu_order: 1200
 ---
 
 ## Swedbank Pay Checkout Test Data

--- a/resources/test-data.md
+++ b/resources/test-data.md
@@ -264,7 +264,6 @@ the following values:
 | TM01        | Swish timed out before the payment was started |
 | BANKIDCL    | Payer cancelled BankId signing                 |
 
-[create-card-purchase]: /old-implementations/payment-instruments-v1/card/redirect#step-1-create-a-purchase
 [3ds-emulator-no-dropdown]: /assets/img/3DS-emulator-no-dropdown.png
 [3ds-emulator-with-dropdown]: /assets/img/3DS-emulator-with-dropdown.png
 [otp-challenge-form]: /assets/img/otp-challenge-form.png


### PR DESCRIPTION
* Removed Introduction from the main menu
* Created "Fundamental Principles" under Resources
* Added all info from Introduction, minus user agent.
* Added User agent as a tech ref section
* Removed Demoshop link from Fundamental principles, as it is present on the front page.
* Cleaned up menu order