### PR TITLE
Hotfix: DX-2163 Payout PATCH response (master)

### DIFF
--- a/_includes/payout.md
+++ b/_includes/payout.md
@@ -399,8 +399,8 @@ Content-Type: application/json
         "availableInstruments": [
             "Trustly"
         ],
-        "implementation": "Enterprise",
-        "integration": "Direct",
+        "implementation": "PaymentsOnly",
+        "integration": "",
         "instrumentMode": false,
         "guestMode": true,
         "urls": {


### PR DESCRIPTION
Changed enterprise to payments only and removed direct as integration.