### PR TITLE
DX-2308: Removed duplicate release notes from intro pages

### DIFF
--- a/checkout-v3/index.md
+++ b/checkout-v3/index.md
@@ -38,6 +38,7 @@ data in compliance with GDPR, but you won't have to worry about handling
 sensitive card info.
 
 ## Use Cases
+
 <div class="row mt-4">
     <div class="col-xxl-3 col-xl-6 col-lg-6 d-flex">
        <a href="/checkout-v3/use-cases/recurring" class="dx-card">
@@ -82,11 +83,6 @@ below to read more." %}
 | ![Swish][swish-logo]             | Swish                            | {% flag se %}                |
 | ![Trustly][trustly-logo]         | [Trustly][trustly]               | {% flag se %} {% flag fi %}  |
 | ![Vipps][vipps-logo]             | Vipps                            | {% flag no %}                |
-
-## What's new in the documentation
-
-  {% include release_notes.html num_dates=3 %}
-  <a href="/checkout-v3/resources/release-notes">See full release notes</a>
 
 ## Resources
 

--- a/pax-terminal/index.md
+++ b/pax-terminal/index.md
@@ -43,11 +43,6 @@ set in the admin menu. To enter the admin menu tap 6 times on the Swedbank Pay
 logo located at the bottom of the screen. Then enter the code. Set the ECR IP
 address and then press the save button.
 
-## What's new in the documentation
-
-  {% include release_notes.html num_dates=3 %}
-  <a href="/pax-terminal/release-notes">See full release notes</a>
-
 [nexoretailer]: /pax-terminal/Nexo-Retailer/
 [dotnetsdk]: /pax-terminal/NET/
 [javasdk]: /pax-terminal/java


### PR DESCRIPTION
The pax and digital payments had a "newest release notes" that were very close to the regular feed and seemed excessive.