### PR TITLE
Release 4.7.0 (develop)

### DIFF
--- a/checkout-v3/release-notes.md
+++ b/checkout-v3/release-notes.md
@@ -11,6 +11,37 @@ menu_order: 10
 body="The version numbers used in headers on this page refers to the version of
 this very documentation, not to a version of any APIs described by it." %}
 
+## 06 Jan 24
+
+### Version 4.7.0
+
+We spent some time building up steam after new years, but we have lots of treats
+lined up.
+
+Are you looking to get started with recurring payments, but not really sure
+where to start? We have compiled everything you need in a [use case][ruc], and
+walk you through it all.
+
+Or are you maybe looking to upgrade to our newest Digital Payments version? See
+how easy it is in our [migration guide][mig-guide].
+
+A new `errorType` goes live any day now, so a preview in the developer portal
+seems fitting. The aim is to give you clearer feedback when a token has become
+inactive. Read more about it in the [problems section][token-problems].
+
+We have also made improvements to the [domain verification][dom-ver] steps of
+our Apple Pay documentation.
+
+The **Resources** are being split up. We have moved the [test-data][test-data]
+and release notes up a level for convenience. Development guidelines are moved
+to [Modules & SDKs][sdk-guidelines] if you need them. The [partners][partners]
+are now on our front page and Data Protection can be found in
+[Checkout v2][data-protection].
+
+In addition to the usual handful of improvements and bug fixes, of course.
+
+Until next time!
+
 ## 19 Dec 23
 
 ### Version 4.6.1
@@ -943,6 +974,7 @@ integration and the payer.
 [demoshop]: https://ecom.externalintegration.payex.com/pspdemoshop
 [design-guide]: https://design.swedbankpay.com/
 [display-ui]: /checkout-v3/display-payment-ui/
+[dom-ver]: /checkout-v3/payment-presentations#domain-verification
 [eligibility-check]: /checkout-v3/features/optional/instrument-mode#eligibility-check
 [mac]: /old-implementations/checkout-v2/features/optional/mac
 [fa]: /checkout-v3/features/technical-reference/resource-sub-models#failedattempts
@@ -961,6 +993,7 @@ integration and the payer.
 [ios-configuration]: /checkout-v3/modules-sdks/mobile-sdk/configuration#ios
 [ios-sdk-documentation]: /checkout-v3/modules-sdks/mobile-sdk/ios
 [mac-checkout]: /old-implementations/checkout-v2/features/optional/mac
+[mig-guide]: /checkout-v3/migration-guide/
 [mobile-card-payments]: /old-implementations/payment-instruments-v1/card/mobile-card-payments
 [mobile-pay]: /old-implementations/payment-instruments-v1/mobile-pay
 [mobilepay-seamless-view]: /old-implementations/payment-instruments-v1/mobile-pay/seamless-view
@@ -999,8 +1032,10 @@ integration and the payer.
 [resources]: /checkout-v3/resources/
 [request-delivery-information]: /checkout-v3/features/optional/request-delivery-info
 [resources]: /checkout-v3/resources/
+[ruc]: /checkout-v3/use-cases/recurring
 [settlement-balance-report]: /old-implementations/payment-instruments-v1/card/features/core/settlement-reconciliation#balance-report
 [settlement-reconcilitation]: /old-implementations/payment-instruments-v1/card/features/core/settlement-reconciliation
+[sdk-guidelines]: /checkout-v3/modules-sdks/development-guidelines
 [sdk-modules]: /checkout-v3/modules-sdks
 [split-settlement]: /checkout-v3/features/optional/split-settlement
 [spp]: https://playground.swedbankpay.com
@@ -1023,6 +1058,7 @@ integration and the payer.
 [technical-reference]: /old-implementations/checkout-v2/features/technical-reference/
 [terminology]: /checkout-v3/resources/terminology
 [test-data]: /checkout-v3/test-data
+[token-problems]: /checkout-v3/features/technical-reference/problems/#token-problems
 [tos-url]: /checkout-v3/features/optional/tos
 [trustly-pres]: /checkout-v3/payment-presentations#trustly
 [transaction-on-file]: /old-implementations/payment-instruments-v1/card/features/optional/transaction-on-file


### PR DESCRIPTION
## 06 Jan 24

### Version 4.7.0

We spent some time building up steam after new years, but we have lots of treats lined up.

Are you looking to get started with recurring payments, but not really sure where to start? We have compiled everything you need in a use case and walk you through it all.

Or are you maybe looking to upgrade to our newest Digital Payments version? See how easy it is in our migration guide.

A new errorType goes live any day now, so a preview in the developer portal seems fitting. The aim is to give you clearer feedback when a token has become inactive. Read more about it in the problems section.

We have also made improvements to the domain verification steps of our Apple Pay documentation.

The Resources are being split up. We have moved the test-data and release notes up a level for convenience. Development guidelines are moved to Modules & SDKs if you need them. The partners are now on our front page, and the Data Protection can be found in Checkout v2. In addition to the usual handful of improvements and bug fixes, of course.

Documentation

DX-2351: More failing links @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2112)
DX-2332: Test commit to see if things work @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2109)
Develop pos @the-anders-jarold (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2110)
DX-2345: Removed sections no longer present from the resource intro @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2106)
DX-2348: Added permalinks to checkout v2 and payment menu v2 @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2105)
DX-2346: Removed episerver link, unsupported disclaimer and magento from text @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2103)
explained TerminalAddressObtainedEventCallback @the-anders-jarold (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2104)
dx-2311 migration guide continued @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2101)
nexo Retailer explained configurtation message @the-anders-jarold (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2102)
DX-2314: Removed Unscheduled Token from response @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2098)
NET use case for fuel transaction @the-anders-jarold (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2100)
CVM signature flow explained @the-anders-jarold (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2099)
DX-2342: Removed resource cards from DP page @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2095)
DX-2341: Added info regarding the new token error types @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2094)
DX-2320: Moved the test data and added redirect @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2093)
described manually entered payment instrument. Also corrected permalinks under NET @the-anders-jarold (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2092)
correceted example fuel payment response @the-anders-jarold (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2091)
Dx 2337 change structure of net sdk to use more cards @the-anders-jarold (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2089)
DX-2335: SDK link removals @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2088)
DX-2317: Moved release notes to sec nav @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2086)
DX-2316: Moved data protection to old implementations checkout v2 @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2083)
DX-2318: Moved Open Source Development Guidelines and updated links @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2082)
DX-2315: Removed the main menu styling page @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2081)
DX-2324: Moved the partner cards to our front page and removed the partner page @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2080)
DX-2334: Updated Apple Pay domain verification text @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2079)
DX-2308: Removed duplicate release notes from intro pages @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2078)
DX-2266: Feedback recurring use case @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2077)
DX-2142: Re-structured some information @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2070)
DX-2296: Tried to add a new release notes section. Needs html work in theme repo. @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2066)
DX-2298: Trying Årsets stage deploy fix. @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2069)
DX-2302: Removed duplicate cancel information and switched include @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2065)
DX-2301: Updated the callback header @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2064)
DX-2303: Remove duplicate capture info @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2063)
DX-2304: Removing duplicate reversal info and added a sequence diagram @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2062)
Release 4.6.1 (develop) @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2058)
👩🏻‍💻 Development

Bump retext-spell from 6.0.0 to 6.1.0 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2111)
Bump npm from 10.3.0 to 10.4.0 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2084)
DX-2322: Updated to theme 2.1.12.pre.beta.2 @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2075)
Bump npm from 10.2.5 to 10.3.0 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2068)
Bump faraday from 2.7.12 to 2.8.1 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2060)
👩🏻‍⚖️ Legal

DX-2318: Moved Open Source Development Guidelines and updated links @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2082)
📝 Configuration

Bump release-drafter/release-drafter from 5 to 6 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2107)
Bump azure/login from 1.6.0 to 1.6.1 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2073)
Bump actions/cache from 3 to 4 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2072)
Bump azure/login from 1.5.1 to 1.6.0 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2067)
DX-2298: Trying Årsets stage deploy fix. @arebra (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2069)
⬆️ Dependencies

Bump retext-spell from 6.0.0 to 6.1.0 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2111)
Bump rspec from 3.12.0 to 3.13.0 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2108)
Bump release-drafter/release-drafter from 5 to 6 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2107)
Bump rubocop from 1.60.1 to 1.60.2 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2085)
Bump npm from 10.3.0 to 10.4.0 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2084)
Bump rubocop from 1.60.0 to 1.60.1 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2074)
Bump azure/login from 1.6.0 to 1.6.1 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2073)
Bump actions/cache from 3 to 4 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2072)
Bump rubocop from 1.59.0 to 1.60.0 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2071)
Bump npm from 10.2.5 to 10.3.0 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2068)
Bump azure/login from 1.5.1 to 1.6.0 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2067)
Bump jekyll from 4.3.2 to 4.3.3 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2061)
Bump faraday from 2.7.12 to 2.8.1 https://github.com/dependabot (https://github.com/SwedbankPay/developer.swedbankpay.com/pull/2060)