### PR TITLE
SDK-1: Update of Mobile SDK documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -69,3 +69,5 @@ defaults:
       front_end_url: https://ecom.externalintegration.payex.com
       consumer_ssn_se: 199710202392
       consumer_ssn_no: 26026708248
+      mobile_sdk_ios_version: 4.0.5
+      mobile_sdk_android_version: 4.1.1

--- a/checkout-v3/modules-sdks/mobile-sdk/android.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/android.md
@@ -404,10 +404,10 @@ application case. Using this argument should not be necessary, however. If you
 do find a case that does not work inside the PaymentFragment, but does work when
 using the browser for third-party sites, please file a bug on the Android SDK.
 
-{% include iterator.html prev_href="/checkout-v3/modules-sdks/mobile-sdk/merchant-backend-sample-code"
-                         prev_title="Merchant Backend Sample Code"
+{% include iterator.html prev_href="/checkout-v3/modules-sdks/mobile-sdk/custom-backend"
+                         prev_title="Back: Custom Backend"
                          next_href="/checkout-v3/modules-sdks/mobile-sdk/ios"
-                         next_title="iOS" %}
+                         next_title="Next: iOS" %}
 
 [maven-group]: https://search.maven.org/search?q=g:com.swedbankpay.mobilesdk
 [sdk-maven]: https://search.maven.org/artifact/com.swedbankpay.mobilesdk/mobilesdk

--- a/checkout-v3/modules-sdks/mobile-sdk/android.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/android.md
@@ -33,8 +33,8 @@ the `build.gradle` file:
 
 ```groovy
 dependencies {
-    implementation 'com.swedbankpay.mobilesdk:mobilesdk:4.0.0'
-    implementation 'com.swedbankpay.mobilesdk:mobilesdk-merchantbackend:4.0.0'
+    implementation 'com.swedbankpay.mobilesdk:mobilesdk:{{ page.mobile_sdk_android_version }}'
+    implementation 'com.swedbankpay.mobilesdk:mobilesdk-merchantbackend:{{ page.mobile_sdk_android_version }}'
 }
 ```
 

--- a/checkout-v3/modules-sdks/mobile-sdk/android.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/android.md
@@ -451,4 +451,4 @@ using the browser for third-party sites, please file a bug on the Android SDK.
 [dokka-swedbankpayproblem]: https://github.com/SwedbankPay/swedbank-pay-sdk-android/blob/dev/sdk/dokka_github/sdk/com.swedbankpay.mobilesdk.merchantbackend/-swedbank-pay-problem/index.md
 [paymenturl]: /old-implementations/checkout-v2/features/technical-reference/payment-url
 [android-helper]: /checkout-v3/modules-sdks/mobile-sdk/merchant-backend#android-payment-url-helper
-[android-intent-scheme]: https://developer.chrome.com/multidevice/android/intents
+[android-intent-scheme]: https://developer.chrome.com/docs/android/intents

--- a/checkout-v3/modules-sdks/mobile-sdk/bare-minimum-implementation.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/bare-minimum-implementation.md
@@ -1,0 +1,401 @@
+---
+title: Bare Minimum Implementation
+permalink: /:path/bare-minimum-implementation/
+description: |
+  Bare minimum implementation of the **Swedbank Pay Mobile SDK**
+menu_order: 800
+---
+
+In this chapter we provide the bare minimum implementation needed to present the
+Swedbank Pay UI using the Mobile SDK. There are several important limitations
+with this implementation that we're listing at the end of the chapter.
+
+## Payment
+
+To start off, you need a payment to present. If you already have a backend
+implementation of the Swedbank Pay APIs, you can use that to initialize a
+payment order. If you don't have a backend implementation, you can manually
+create a payment order using Swagger or a similar tool.
+
+For simplicity, we're specifying some simple placeholder values and URLs when
+creating the payment order that you can use as well. There is no need for the
+bare minimum implementation to provide URLs to actual working sites:
+
+```http
+POST /psp/paymentorders HTTP/1.1
+Host: {{ page.api_host }}
+Authorization: Bearer <AccessToken>
+Content-Type: application/json;version=3.1
+
+{
+    "paymentorder": {
+        "operation": "Purchase",
+        "currency": "SEK",
+        "amount": 1500,
+        "vatAmount": 375,
+        "description": "Test App Purchase",
+        "userAgent": "SDK-Test",
+        "language": "sv-SE",
+        "instrument": null,
+        "urls": {
+            "hostUrls": [ "https://example.com" ],
+            "paymentUrl": "examplepayment://payment/",
+            "completeUrl": "https://example.com/payment-completed",
+            "cancelUrl": "https://example.com/payment-cancelled",
+            "termsOfServiceUrl": "https://example.com/tos",
+            "callbackUrl": "https://api.example.com/payment-callback"
+        },
+        "payeeInfo": {
+            "payeeId": "{{ page.merchant_id }}",
+            "payeeReference": "AB832",
+            "payeeName": "Merchant1",
+            "orderReference": "or-123456"
+        }
+    }
+}
+```
+
+After the payment order is created, you can fetch it to get the available
+operations. The operation you're interested in for the sake of the bare minimum
+implementation is the `view-checkout`.
+
+```json
+{
+  "paymentOrder": { ... }
+  "operations": [
+    {
+      "method": "GET",
+      "href": "{{ page.front_end_url }}/payment/core/js/px.payment.client.js?token={{ page.payment_token }}&culture=nb-NO&_tc_tid=30f2168171e142d38bcd4af2c3721959",
+      "rel": "view-checkout",
+      "contentType": "application/javascript"
+    },
+    ...
+  ]
+}
+```
+
+The `href` from the operation is then used in the Android and iOS implementations below.
+
+## Android
+
+Integrate the SDK in your application by simply adding the dependency to the
+`build.gradle` file:
+
+```groovy
+dependencies {
+    implementation 'com.swedbankpay.mobilesdk:mobilesdk:{{ page.mobile_sdk_android_version }}'
+}
+```
+
+Or in your `gradle.kts` file:
+
+```kotlin
+dependencies {
+    implementation("com.swedbankpay.mobilesdk:mobilesdk:{{ page.mobile_sdk_android_version }}")
+}
+```
+
+Depending on your app, you might also need to add
+`androidx.appcompat:appcompat:1.6.1`
+
+## Android Setup
+
+If you would like the implementation to have basic return URL functionality
+(that is, having the ability for external apps like Vipps and BankID to return
+back to your app automatically after they are done) you need to make sure that
+the payment URL will launch the app. A basic way to enable this is a custom URL
+scheme (`examplepayment://`). To make the your app launch for such URLs in the
+system, you need to add the following to your manifest file:
+
+```xml
+<activity android:name=".MainActivity">
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="examplepayment" android:host="path" />
+    </intent-filter>
+</activity>
+```
+
+## Android SDK Configuration
+
+Next, you provide the configuration for the payment UI. We don't use consumer
+identification for the bare minimum implementation, so that method is
+implemented but does not return any data. The payment order returned have
+URLs matching the payment order you created earlier. Provide the `view-checkout`
+operation `href` in the `viewPaymentLink` parameter of `ViewPaymentOrderInfo`.
+
+```kotlin
+class TestConfiguration : Configuration() {
+
+    // This method is required but not used
+    override suspend fun postConsumers(
+        context: Context,
+        consumer: Consumer?,
+        userData: Any?
+    ): ViewConsumerIdentificationInfo {
+        throw Exception()
+    }
+
+    override suspend fun postPaymentorders(
+        context: Context,
+        paymentOrder: PaymentOrder?,
+        userData: Any?,
+        consumerProfileRef: String?
+    ): ViewPaymentOrderInfo {
+        return ViewPaymentOrderInfo(
+            viewPaymentLink = "{{ page.front_end_url }}/payment/core/js/px.payment.client.js?token={{ page.payment_token }}&culture=nb-NO&_tc_tid=30f2168171e142d38bcd4af2c3721959",
+            webViewBaseUrl = "https://example.com/",
+            completeUrl = "https://example.com/complete",
+            cancelUrl = "https://example.com/cancel",
+            paymentUrl = "examplepayment://payment/",
+            isV3 = true
+        )
+    }
+}
+```
+
+## Android Present Payment
+
+You are now ready to present the payment UI. First, you set our configuration as
+the global `defaultConfiguration` for `PaymentFragment` in your app:
+
+```kotlin
+val configuration = TestConfiguration()
+PaymentFragment.defaultConfiguration = configuration
+```
+
+After this, you simply create a `PaymentFragment` instance and present it in a
+way that works in your application (in this example, we're accessing the
+Appcompat `FragmentManager` via `supportFragmentManager`, meaning this code is
+implemented in an `Activity` of the app):
+
+```kotlin
+val arguments = PaymentFragment.ArgumentsBuilder()
+    .checkoutV3(true)
+    .build()
+
+val paymentFragment = PaymentFragment()
+paymentFragment.arguments = arguments
+
+val containerViewId = R.id.sdk_payment_fragment // Specify a container ID for the fragment
+supportFragmentManager.beginTransaction()
+    .add(containerViewId, paymentFragment)
+    .commit()
+```
+
+You want to listen to some basic state updates from the payment UI and dismiss
+the view when it's finished. You do this by accessing the `paymentViewModel`
+that is available on all Activities. In the following example, we observe the
+`state` variable in the same Activity as above, and remove the payment fragment
+from the screen after the payment is finalized (again, this is done with
+`supportFragmentManager`, you can modify this depending on how you presented the
+fragment):
+
+```kotlin
+paymentViewModel.state.observe(this, Observer {
+    if (it.isFinal == true) {
+        supportFragmentManager.beginTransaction()
+            .remove(paymentFragment)
+            .commit()
+    }
+})
+```
+
+## iOS
+
+Integrate the SDK in your application by either using Swift Package Manager or
+CocoaPods.
+
+### Swift Package Manager
+
+The package repository URL for the SDK is
+[`https://github.com/SwedbankPay/swedbank-pay-sdk-ios.git`][sdk-package-repo].
+Add the `SwedbankPaySDK` library, there is no need to add the 
+`SwedbankPaySDKMerchantBackend` library for the bare minimum implementation.
+
+### CocoaPods
+
+Add the dependency in your `Podfile`:
+
+```ruby
+pod 'SwedbankPaySDK', '~> {{ page.mobile_sdk_ios_version }}'
+```
+
+## iOS Setup
+
+If you would like the implementation to have basic return URL functionality
+(that is, having the ability for external apps like Vipps and BankID to return
+back to your app automatically after they are done) you need to make sure that
+the payment URL will launch the app. A basic way to enable this is a custom URL
+scheme (`examplepayment://`).
+
+The easiest way to add a URL scheme to your app is to select the project file,
+go to the `Info` tab, scroll down to `URL Types`, and click the `+` button to
+add a new scheme. Insert `examplepayment` to the `URL Schemes` field. You can
+choose the URL `Identifier` freely, but remember that that it should be unique.
+The `Role` for the url type should be `Editor`. Finally, to mark this url type
+as the Swedbank Pay payment url scheme, open the `Additional url type
+properties`, and add a property with the key
+`com.swedbank.SwedbankPaySDK.callback`, type `Boolean`, and value `YES`.
+
+![Payment url scheme added in project Info tab][custom-scheme-1]
+
+You can also edit the `Info.plist` file directly, if you wish.
+
+![Payment url scheme added in Info.plist editor][custom-scheme-2]
+
+To forward the custom-scheme payment urls to the SDK, implement the
+[`application(_:open:options:)`][uiappdelegate-openurl] method in your
+application delegate, and call `SwedbankPaySDK.open(url: url)` to let the SDK
+handle the url.
+
+```swift
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    return SwedbankPaySDK.open(url: url)
+}
+```
+
+## iOS SDK Configuration
+
+Next, you provide the configuration for the payment UI. We don't use consumer
+identification for the bare minimum implementation, so that method is
+implemented but does not return any data. The payment order returned have
+URLs matching the payment order you created earlier. Provide the `view-checkout`
+operation `href` in the `viewPaymentLink` parameter of `ViewPaymentOrderInfo`.
+
+Provide the `view-checkout` operation `href` in the `viewPaymentLink` parameter
+of `ViewPaymentOrderInfo`;
+
+```swift
+enum SwedbankPayConfigurationError: Error {
+    case notImplemented
+}
+
+class TestConfiguration: SwedbankPaySDKConfiguration {
+
+    // This delegate method is required but not used
+    func postConsumers(consumer: SwedbankPaySDK.Consumer?,
+                       userData: Any?,
+                       completion: @escaping (Result<SwedbankPaySDK.ViewConsumerIdentificationInfo, Error>) -> Void) {
+        completion(.failure(SwedbankPayConfigurationError.notImplemented))
+    }
+    
+    func postPaymentorders(paymentOrder: SwedbankPaySDK.PaymentOrder?,
+                           userData: Any?,
+                           consumerProfileRef: String?,
+                           options: SwedbankPaySDK.VersionOptions,
+                           completion: @escaping (Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>) -> Void) {
+        let info = SwedbankPaySDK.ViewPaymentOrderInfo(isV3: true,
+                                                       webViewBaseURL: URL(string: "https://example.com/"),
+                                                       viewPaymentLink: URL(string: "{{ page.front_end_url }}/payment/core/js/px.payment.client.js?token={{ page.payment_token }}&culture=nb-NO&_tc_tid=30f2168171e142d38bcd4af2c3721959")!,
+                                                       completeUrl: URL(string: "https://example.com/complete")!,
+                                                       cancelUrl: URL(string: "https://example.com/cancel"),
+                                                       paymentUrl: URL(string: "examplepayment://payment/"),
+                                                       termsOfServiceUrl: URL(string: "https://example.com/tos"))
+        completion(.success(info))
+    }
+
+}
+```
+
+## iOS Present Payment
+
+You want to listen to some basic state updates from the payment UI and dismiss
+the view when it's finished. You do this by implementing the
+`SwedbankPaySDKDelegate` protocol. In the following example, we implement
+the delegate protocol and the following three delegate methods in a view
+controller. We will be presenting the payment view controller modally in the
+implementation further down, so we can use `dismiss()` to close it:
+
+```swift
+func paymentComplete() {
+    dismiss(animated: true)
+    print("Payment Complete")
+}
+
+func paymentCanceled() {
+    dismiss(animated: true)
+    print("Payment Canceled")
+}
+
+func paymentFailed(error: Error) {
+    dismiss(animated: true)
+    print("Payment Failed")
+}
+```
+
+You are now ready to present the payment UI. Simply create a
+`SwedbankPaySDKController`, provide the configuration, assign the `delegate`
+and present it in a way that works in your application (again, in the example
+we're presenting the view modally in a separate View Controller):
+
+```swift
+let configuration = TestConfiguration()
+let paymentController = SwedbankPaySDKController(configuration: configuration,
+                                                 withCheckin: false,
+                                                 consumer: nil,
+                                                 paymentOrder: nil,
+                                                 userData: nil)
+
+paymentController.delegate = self
+
+present(paymentController, animated: true)
+```
+
+## Limitations of the minimal implementation
+
+While you can use the steps above to present a payment UI in your apps with very
+little work, there are several limitations to the implementation that you should
+consider before choosing how to implement the full payment in your apps.
+
+### Dynamic configuration
+
+For simplicity, we've hardcoded all URLs needed to initiliaze the configuration.
+In an actual application, you instead need to fetch one ore more URLs from your
+backend and supply it to the payment UI. The obvious URL that is required to be
+dynamic is the payment order specific `viewPaymentLink`, but also URLs such as
+`paymentUrl` should ideally be dynamic (depending on mobile platform and even
+the payment order, more on this below).
+
+### Cancelling payment
+
+In this implementation, we haven't included a way for the user to cancel the
+payment order. You could achieve this functionality by adding a cancel button
+to your UI (for example providing a navigation bar with a close button for the
+payment UI view controller/fragment), and cancelling the payment order via your
+backend.
+
+### Payment URL Handling
+
+In this minimal implementation, we used custom URL scheme for the payment URL.
+This causes several issues in a production environment:
+
+* On iOS, using custom URL schemes instead of Universal Links comes with several
+drawbacks, including prompting the user with an additional confirmation popup
+as well as being unable to verify URL ownership to your specific app (other
+apps can declare the same custom URL scheme outside of your control).
+* On Android, the SDK expects the app to be launched by external apps using an
+`intent:` scheme URL. This ties into the intent filter contained in the SDK,
+that will bring the containing application to the foreground and reload the
+payment menu. Because we're using the simpler custom URL scheme in this
+implementation, the payment menu will not reload and this will result in some
+payment instruments not behaving correctly.
+* There are a few, albeit rare, scenarios where the user can end up launching
+the Payment URL in the mobile browser on their phone. For URLs with custom
+schemes that's handled nicely, but for universal URLs, it's more problematic.
+This means that browsing to the payment URL ideally should return a view that
+redirects the user to the app. We provide example on how to implement this in
+the next chapter [Custom Backend][payemnt-url].
+
+{% include iterator.html prev_href="/checkout-v3/modules-sdks/mobile-sdk/configuration"
+                         prev_title="Back: Configuration"
+                         next_href="/checkout-v3/modules-sdks/mobile-sdk/custom-backend"
+                         next_title="Next: Custom Backend" %}
+
+[sdk-package-repo]: https://github.com/SwedbankPay/swedbank-pay-sdk-ios.git
+[custom-scheme-1]: /assets/img/mobile-sdk/ios-custom-scheme-1.png
+[custom-scheme-2]: /assets/img/mobile-sdk/ios-custom-scheme-2.png
+[uiappdelegate-openurl]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application
+[payemnt-url]: /checkout-v3/modules-sdks/mobile-sdk/custom-backend/#payment-url

--- a/checkout-v3/modules-sdks/mobile-sdk/configuration.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/configuration.md
@@ -118,9 +118,9 @@ provided if you need to implement your Configuration in Java instead.
 
 As the mobile application cannot talk directly to Swedbank Pay servers, you will
 need your own backend to make those requests on the behalf of your
-Configuration. You are free to design your backend as best suits you, but the
-next chapter will detail one possible implementation, which also has a
-bundled-in Configuration implementation available in the SDK.
+Configuration. You are free to design your backend as best suits you, but there
+is also a chapter that will detail one possible example implementation, which
+also has a bundled-in Configuration implementation available in the SDK.
 
 One thing you should keep in mind while designing your backend is that the
 `paymentUrl` of your payment order needs special consideration in order to work
@@ -132,11 +132,8 @@ This can be accomplished by having `paymentUrl` return a redirect response; the
 details of that redirect will be discussed in the platform-specific pages. It is
 recommneded that `paymentUrl` be unique to each payment order that you create.
 
-The next chapter will go over the Merchant Backend API. It will also explore in
-detail how `paymentUrl` is handled on a server implementing the Merchant Backend
-API. The SDK comes ready with a Configuration suitable for a server implementing
-the Merchant Backend API, which will be discussed in detail in the client
-platform specific chapters.
+The next chapter will go over a custom backend implementation. It will also
+detail how `paymentUrl` should be handled.
 
 {% include iterator.html prev_href="./"
                          prev_title="Back: Introduction"

--- a/checkout-v3/modules-sdks/mobile-sdk/configuration.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/configuration.md
@@ -140,7 +140,7 @@ platform specific chapters.
 
 {% include iterator.html prev_href="./"
                          prev_title="Back: Introduction"
-                         next_href="/checkout-v3/modules-sdks/mobile-sdk/merchant-backend"
-                         next_title="Next: Merchant Backend" %}
+                         next_href="/checkout-v3/modules-sdks/mobile-sdk/bare-minimum-implementation"
+                         next_title="Next: Bare Minimum Implementation" %}
 
 [dokka-config]: https://github.com/SwedbankPay/swedbank-pay-sdk-android/blob/dev/sdk/dokka_github/sdk/com.swedbankpay.mobilesdk/-configuration/index.md

--- a/checkout-v3/modules-sdks/mobile-sdk/configuration.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/configuration.md
@@ -56,7 +56,6 @@ protocol. The protocol has two required methods:
             userData: Any?,
             consumerProfileRef: String?,
             completion: @escaping (Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>) -> Void
-
         ) {
            // code
         }
@@ -130,7 +129,7 @@ will, in some cases, be opened in the browser application, and at that point we
 must take some measures to return to your application to continue the payment.
 This can be accomplished by having `paymentUrl` return a redirect response; the
 details of that redirect will be discussed in the platform-specific pages. It is
-recommneded that `paymentUrl` be unique to each payment order that you create.
+recommended that `paymentUrl` be unique to each payment order that you create.
 
 The next chapter will go over a custom backend implementation. It will also
 detail how `paymentUrl` should be handled.

--- a/checkout-v3/modules-sdks/mobile-sdk/custom-backend.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/custom-backend.md
@@ -1,9 +1,9 @@
 ---
-title: Mobile SDK – Custom Backend
+title: Custom Backend
 permalink: /:path/custom-backend/
 description: |
   You can also build a fully custom backend for the **Swedbank Pay Mobile SDK**
-menu_order: 1200
+menu_order: 900
 ---
 
 In this chapter we explore how to integrate the mobile SDK with a fully custom
@@ -721,10 +721,10 @@ specify the allowed custom scheme, you can conform to
     }
 ```
 
-{% include iterator.html prev_href="/checkout-v3/modules-sdks/mobile-sdk/ios"
-                         prev_title="Back: iOS"
-                         next_href="/checkout-v3/modules-sdks/mobile-sdk/other-features"
-                         next_title="Next: Other Features" %}
+{% include iterator.html prev_href="/checkout-v3/modules-sdks/mobile-sdk/bare-minimum-implementation"
+                         prev_title="Back: Bare Minimum Implementation"
+                         next_href="/checkout-v3/modules-sdks/mobile-sdk/android"
+                         next_title="Next: Android" %}
 
 [initiate-consumer-session]: /old-implementations/checkout-v2/checkin#step-1-initiate-session-for-consumer-identification
 [create-payment-order]: /old-implementations/checkout-v2/payment-menu#step-3-create-payment-order

--- a/checkout-v3/modules-sdks/mobile-sdk/custom-backend.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/custom-backend.md
@@ -31,8 +31,8 @@ To bind the SDK to your custom backend, you must create a subclass of
 cannot use Kotlin, you can use the compatibility class
 `com.swedbankpay.mobilesdk.ConfigurationCompat`.
 
-Your subclass must provide implementations of `postConsumers` and
-`postPaymentorders`. These methods are named after the corresponding Swedbank
+Your subclass must provide implementations of `postPaymentorders` and
+`postConsumers`. These methods are named after the corresponding Swedbank
 Pay APIs they are intended to be forwarded to. If you do not intend to use
 consumer identification, you can have your `postConsumers` implementation throw
 an exception.
@@ -44,53 +44,55 @@ consumer reference will be passed in the `consumerProfileRef` argument of
 `postPaymentorders`. The exact implementation of these methods is outside the
 scope of this document.
 
-You must return a `ViewConsumerIdentificationInfo` and a `ViewPaymentOrderInfo`
-object respectively; please refer to their class documentation on how to
-populate them from your backend responses. Any exception you throw from these
-methods will in turn be reported from the `PaymentViewModel`. Whether a given
-exception is treated as a retryable condition is controlled by the
-`shouldRetryAfter<Operation>Exception` methods; by default they only consider
-`IllegalStateException` as fatal. Please refer to the `Configuration`
-documentation on all the features.
+You must return a `ViewPaymentOrderInfo` and optionally also a
+`ViewConsumerIdentificationInfo` object respectively; please refer to their
+class documentation on how to populate them from your backend responses. Any
+exception you throw from these methods will in turn be reported from the
+`PaymentViewModel`. Whether a given exception is treated as a retryable
+condition is controlled by the `shouldRetryAfter<Operation>Exception` methods;
+by default they only consider `IllegalStateException` as fatal. Please refer to
+the `Configuration` documentation on all the features.
 
 ```kotlin
-    class MyConfiguration : Configuration() {
-        suspend fun postConsumers(
-            context: Context,
-            consumer: Consumer?,
-            userData: Any?
-        ): ViewConsumerIdentificationInfo {
-            val viewConsumerIdentification = post("https://example.com/identify")
-            return ViewConsumerIdentificationInfo(
-                webViewBaseUrl = "https://example.com/",
-                viewConsumerIdentification = viewConsumerIdentification
-            )
-        }
-
-        suspend fun postPaymentorders(
-            context: Context,
-            paymentOrder: PaymentOrder?,
-            userData: Any?,
-            consumerProfileRef: String?
-        ): ViewPaymentOrderInfo {
-            val viewPaymentOrder = post("https://example.com/pay/android")
-            return ViewPaymentOrderInfo(
-                webViewBaseUrl = "https://example.com/",
-                viewPaymentOrder = viewPaymentOrder,
-                completeUrl = "https://example.com/complete",
-                cancelUrl = "https://example.com/cancel",
-                paymentUrl = "https://example.com/payment/android",
-                termsOfServiceUrl = "https://example.com/tos"
-            )
-        }
+class MyConfiguration : Configuration() {
+    override suspend fun postPaymentorders(
+        context: Context,
+        paymentOrder: PaymentOrder?,
+        userData: Any?,
+        consumerProfileRef: String?
+    ): ViewPaymentOrderInfo {
+        val viewPaymentOrder = post("https://example.com/pay/android")
+        return ViewPaymentOrderInfo(
+            viewPaymentLink = "https://example.com/",
+            viewPaymentOrder = viewPaymentOrder,
+            completeUrl = "https://example.com/complete",
+            cancelUrl = "https://example.com/cancel",
+            paymentUrl = "https://example.com/payment/android",
+            termsOfServiceUrl = "https://example.com/tos",
+            isV3 = true
+        )
     }
+
+    override suspend fun postConsumers(
+        context: Context,
+        consumer: Consumer?,
+        userData: Any?
+    ): ViewConsumerIdentificationInfo {
+        val viewConsumerIdentification = post("https://example.com/identify")
+        return ViewConsumerIdentificationInfo(
+            webViewBaseUrl = "https://example.com/",
+            viewConsumerIdentification = viewConsumerIdentification
+        )
+        // Or throw Exception() if not using consumer identification
+    }
+}
 ```
 
 ## iOS Configuration
 
 On iOS you must conform to the `SwedbankPaySDKConfiguration` protocol. Just like
-on Android, you must provide implementations for the `postConsumers` and
-`postPaymentorders` methods. The `consumer`, `paymentOrder`, and `userData`
+on Android, you must provide implementations for the `postPaymentorders` and
+`postConsumers` methods. The `consumer`, `paymentOrder`, and `userData`
 arguments to those methods will be the values you initialize your
 `SwedbankPaySDKController` with, and their meaning is up to you. The
 `postPaymentorders` method will optionally receive a `consumerProfileRef`
@@ -98,58 +100,55 @@ argument, if the consumer was identified before creating the payment order.
 
 The methods are asynchronous, and the result is reported by calling the
 `completion` callback with the result. Successful results have payloads of
-`SwedbankPaySDK.ViewConsumerIdentificationInfo` and
-`SwedbankPaySDK.ViewPaymentOrderInfo`, respectively; please refer to the type
-documentation on how to populate those types. The error of any failure result
-you report will be propagated back to your app in the `paymentFailed(error:)`
-delegate method. You must call the `completion` callback exactly once, multiple
-calls are a programing error.
+`SwedbankPaySDK.ViewPaymentOrderInfo` and
+`SwedbankPaySDK.ViewConsumerIdentificationInfo`, respectively; please refer to
+the type documentation on how to populate those types. If you do not intend to
+use consumer identification, your `postConsumers` should callback should be
+called with a failing result of `SwedbankPayConfigurationError.notImplemented`.
+The other errors of any failure result you report will be propagated back to
+your app in the `paymentFailed(error:)` delegate method. You must call the
+`completion` callback exactly once, multiple calls are a programming error.
 
 ```swift
-    struct MyConfiguration : SwedbankPaySDKConfiguration {
-        func postConsumers(
-            consumer: SwedbankPaySDK.Consumer?,
-            userData: Any?,
-            completion: @escaping (Result<SwedbankPaySDK.ViewConsumerIdentificationInfo, Error>) -> Void
-        ) {
-            post("https://example.com/identify") { result in
-                do {
-                    let viewConsumerIdentification = try result.get()
-                    let info = ViewConsumerIdentificationInfo(
-                        webViewBaseURL: "https://example.com/",
-                        viewConsumerIdentification: viewConsumerIdentification
-                    )
-                    completion(.success(info))
-                } catch let error {
-                    completion(.failure(error))
-                }
-            }
-        }
-
-        func postPaymentorders(
-            paymentOrder: SwedbankPaySDK.PaymentOrder?,
-            userData: Any?,
-            consumerProfileRef: String?,
-            completion: @escaping (Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>) -> Void
-        ) {
-            post("https://example.com/pay/ios") { result in
-                do {
-                    let viewPaymentorder = try result.get()
-                    let info = ViewPaymentOrderInfo(
-                        webViewBaseURL: "https://example.com/",
-                        viewPaymentorder: viewPaymentorder,
-                        completeUrl: "https://example.com/complete",
-                        cancelUrl: "https://example.com/cancel",
-                        paymentUrl: "https://example.com/payment/ios",
-                        termsOfServiceUrl: "https://example.com/tos"
-                    )
-                    completion(.success(info))
-                } catch {
-                    completion(.failure(error))
-                }
+struct MyConfiguration : SwedbankPaySDKConfiguration {
+    func postPaymentorders(paymentOrder: SwedbankPaySDK.PaymentOrder?,
+                           userData: Any?,
+                           consumerProfileRef: String?,
+                           options: SwedbankPaySDK.VersionOptions,
+                           completion: @escaping (Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>) -> Void) {
+        post(URL(string: "https://example.com/pay/ios")!) { result in
+            do {
+                let viewPaymentorder = try result.get()
+                let info = SwedbankPaySDK.ViewPaymentOrderInfo(isV3: true,
+                                                               webViewBaseURL: URL(string: "https://example.com/"),
+                                                               viewPaymentLink: viewPaymentorder,
+                                                               completeUrl: URL(string: "https://example.com/complete")!,
+                                                               cancelUrl: URL(string: "https://example.com/cancel"),
+                                                               paymentUrl: URL(string: "https://example.com/payment/ios"),
+                                                               termsOfServiceUrl: URL(string: "https://example.com/tos"))
+                completion(.success(info))
+            } catch {
+                completion(.failure(error))
             }
         }
     }
+
+    func postConsumers(consumer: SwedbankPaySDK.Consumer?,
+                       userData: Any?,
+                       completion: @escaping (Result<SwedbankPaySDK.ViewConsumerIdentificationInfo, Error>) -> Void) {
+        post(URL(string: "https://example.com/identify")!) { result in
+            do {
+                let viewConsumerIdentification = try result.get()
+                let info = SwedbankPaySDK.ViewConsumerIdentificationInfo(webViewBaseURL: URL(string: "https://example.com/"),
+                                                                         viewConsumerIdentification: viewConsumerIdentification)
+                completion(.success(info))
+            } catch let error {
+                completion(.failure(error))
+            }
+        }
+        // Or completion(.failure(SwedbankPayConfigurationError.notImplemented)) if not using consumer identification
+    }
+}
 ```
 
 ## Backend
@@ -555,25 +554,26 @@ this is the first update, the original `postPaymentorders` call). The
 you.
 
 ```kotlin
-    class MyConfiguration : Configuration() {
-        override suspend fun updatePaymentOrder(
-            context: Context,
-            paymentOrder: PaymentOrder?,
-            userData: Any?,
-            viewPaymentOrderInfo: ViewPaymentOrderInfo,
-            updateInfo: Any?
-        ): ViewPaymentOrderInfo {
-            val viewPaymentOrder = post("https://example.com/payment/android/frobnicate")
-            return ViewPaymentOrderInfo(
-                webViewBaseUrl = "https://example.com/",
-                viewPaymentOrder = viewPaymentOrder,
-                completeUrl = "https://example.com/complete",
-                cancelUrl = "https://example.com/cancel",
-                paymentUrl = "https://example.com/payment/android",
-                termsOfServiceUrl = "https://example.com/tos"
-            )
-        }
+class MyConfiguration : Configuration() {
+    override suspend fun updatePaymentOrder(
+        context: Context,
+        paymentOrder: PaymentOrder?,
+        userData: Any?,
+        viewPaymentOrderInfo: ViewPaymentOrderInfo,
+        updateInfo: Any?
+    ): ViewPaymentOrderInfo {
+        val viewPaymentOrder = post("https://example.com/payment/android/frobnicate")
+        return ViewPaymentOrderInfo(
+            viewPaymentLink = "https://example.com/",
+            viewPaymentOrder = viewPaymentOrder,
+            completeUrl = "https://example.com/complete",
+            cancelUrl = "https://example.com/cancel",
+            paymentUrl = "https://example.com/payment/android",
+            termsOfServiceUrl = "https://example.com/tos",
+            isV3 = true
+        )
     }
+}
 ```
 
 To trigger an update, call `updatePaymentOrder` on the `PaymentViewModel` of the
@@ -581,7 +581,7 @@ active payment. The argument of that call will be passed to your
 `Configuration.updatePaymentOrder` as the `updateInfo` argument.
 
 ```kotlin
-    activity.paymentViewModel.updatePaymentOrder("frob")
+activity.paymentViewModel.updatePaymentOrder("frob")
 ```
 
 ## iOS
@@ -595,35 +595,32 @@ can be used to cancel the request if needed. If the request is cancelled, the
 `completion` callback should _not_ be called.
 
 ```swift
-    struct MyConfiguration : SwedbankPaySDKConfiguration {
-        func updatePaymentOrder(
-            paymentOrder: SwedbankPaySDK.PaymentOrder?,
-            userData: Any?,
-            viewPaymentOrderInfo: SwedbankPaySDK.ViewPaymentOrderInfo,
-            updateInfo: Any,
-            completion: @escaping (Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>) -> Void
-        ) -> SwedbankPaySDKRequest? {
-            val request = post("https://example.com/payment/ios/frobnicate") { result in
-                do {
-                    let viewPaymentorder = try result.get()
-                    let info = ViewPaymentOrderInfo(
-                        webViewBaseURL: "https://example.com/",
-                        viewPaymentorder: viewPaymentorder,
-                        completeUrl: "https://example.com/complete",
-                        cancelUrl: "https://example.com/cancel",
-                        paymentUrl: "https://example.com/payment/ios",
-                        termsOfServiceUrl: "https://example.com/tos"
-                    )
-                    completion(.success(info))
-                } catch NetworkError.cancelled {
-                    // no callback
-                } catch {
-                    completion(.failure(error))
-                }
-            }
-            return request
+func updatePaymentOrder(paymentOrder: SwedbankPaySDK.PaymentOrder?,
+                        options: SwedbankPaySDK.VersionOptions,
+                        userData: Any?,
+                        viewPaymentOrderInfo: SwedbankPaySDK.ViewPaymentOrderInfo,
+                        updateInfo: Any,
+                        completion: @escaping (Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>) -> Void) -> SwedbankPaySDKRequest? {
+    var request = post(URL(string: "https://example.com/payment/ios/frobnicate")!) { result in
+        do {
+            let viewPaymentorder = try result.get()
+            let info = SwedbankPaySDK.ViewPaymentOrderInfo(isV3: true,
+                                                           webViewBaseURL: URL(string: "https://example.com/"),
+                                                           viewPaymentLink: viewPaymentorder,
+                                                           completeUrl: URL(string: "https://example.com/complete")!,
+                                                           cancelUrl: URL(string: "https://example.com/cancel"),
+                                                           paymentUrl: URL(string: "https://example.com/payment/ios"),
+                                                           termsOfServiceUrl: URL(string: "https://example.com/tos"))
+            completion(.success(info))
+        } catch NetworkError.cancelled {
+            // no callback
+
+        } catch {
+            completion(.failure(error))
         }
     }
+    return request
+}
 ```
 
 To trigger an update, call `updatePaymentOrder` on the
@@ -631,9 +628,9 @@ To trigger an update, call `updatePaymentOrder` on the
 the `updateInfo` argument.
 
 ```swift
-    swedbankPayController.updatePaymentOrder(
-        updateInfo: "frob"
-    )
+swedbankPayController.updatePaymentOrder(
+    updateInfo: "frob"
+)
 ```
 
 ## Backend
@@ -684,15 +681,13 @@ also modify this behavior by the `webRedirectBehavior` property of
 `SwedbankPaySDKController`.
 
 ```swift
-    struct MyConfiguration : SwedbankPaySDKConfiguration {
-        func decidePolicyForPaymentMenuRedirect(
-            navigationAction: WKNavigationAction,
-            completion: @escaping (SwedbankPaySDK.PaymentMenuRedirectPolicy) -> Void
-        ) {
-            // we like to live dangerously, allow everything
-            completion(.openInWebView)
-        }
+struct MyConfiguration : SwedbankPaySDKConfiguration {
+    func decidePolicyForPaymentMenuRedirect(navigationAction: WKNavigationAction,
+                                            completion: @escaping (SwedbankPaySDK.PaymentMenuRedirectPolicy) -> Void) {
+        // we like to live dangerously, allow everything
+        completion(.openInWebView)
     }
+}
 ```
 
 ## iOS Payment URL Matching
@@ -706,19 +701,19 @@ specify the allowed custom scheme, you can conform to
 `SwedbankPaySDKConfigurationWithCallbackScheme` instead.
 
 ```swift
-    struct MyConfiguration : SwedbankPaySDKConfiguration {
-        func url(_ url: URL, matchesPaymentUrl paymentUrl: URL) -> Bool {
-            // We trust universal links enough
-            // so we do not need the custom-scheme fallback
-            return url == paymentUrl
-        }
+struct MyConfiguration : SwedbankPaySDKConfiguration {
+    func url(_ url: URL, matchesPaymentUrl paymentUrl: URL) -> Bool {
+        // We trust universal links enough
+        // so we do not need the custom-scheme fallback
+        return url == paymentUrl
     }
+}
 ```
 
 ```swift
-    struct MyConfiguration : SwedbankPaySDKConfigurationWithCallbackScheme {
-        let callbackScheme = "com.example.app"
-    }
+struct MyConfiguration : SwedbankPaySDKConfigurationWithCallbackScheme {
+    let callbackScheme = "com.example.app"
+}
 ```
 
 {% include iterator.html prev_href="/checkout-v3/modules-sdks/mobile-sdk/bare-minimum-implementation"

--- a/checkout-v3/modules-sdks/mobile-sdk/custom-backend.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/custom-backend.md
@@ -2,26 +2,26 @@
 title: Custom Backend
 permalink: /:path/custom-backend/
 description: |
-  You can also build a fully custom backend for the **Swedbank Pay Mobile SDK**
+  Implementing a custom backend for the **Swedbank Pay Mobile SDK**
 menu_order: 900
 ---
 
 In this chapter we explore how to integrate the mobile SDK with a fully custom
-backend server. It is recommended that you first read through the previous
-chapters and gain an understanding of how the SDK works with a backend
-implementing the Merchant Backend API.
+backend server. It is recommended that you also read through the chapters 
+covering the example Merchant Backend API and gain an understanding of how the
+SDK works with that as backend.
 
 ## Basic Backend Requirements
 
 To support the SDK, your backend must be capable of at least [creating a payment
 order][create-payment-order]. If you wish to use consumer identification, it
 must also be able to [start an identification
-session][initiate-consumer-session]. In addition to these, your backend must
+session][initiate-consumer-session]. In addition to these, your backend should
 serve the appropriate html documents at urls used for the
 [`paymentUrl`][payment-url]; the content of these html documents will be
 discussed below, but it is noteworthy that they are different for payments from
 Android applications and those from iOS applications. Further, the urls used for
-as `paymentUrl` on iOS must be [configured as universal links for your iOS
+as `paymentUrl` on iOS should be [configured as universal links for your iOS
 application][ios-aasa].
 
 ## Android Configuration

--- a/checkout-v3/modules-sdks/mobile-sdk/features/index.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/features/index.md
@@ -6,5 +6,5 @@ description: |
   In this section you can read more about the different features of
   mobile SDKs.
 permalink: /:path/
-menu_order: 1000
+menu_order: 1400
 ---

--- a/checkout-v3/modules-sdks/mobile-sdk/index.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/index.md
@@ -65,10 +65,6 @@ The [Post-Purchase][post-purchase-capture] part is the same as when using
 Checkout on a web page, and is thus intentionally left out of the scope of the
 SDK.
 
-See below for a sequence diagram of a payment made using the Mobile SDK. This is
-a high-level diagram. More detailed views highlighting platform differences will
-follow for each step.
-
 {% include iterator.html next_href="configuration"
                          next_title="Next: Configuration" %}
 

--- a/checkout-v3/modules-sdks/mobile-sdk/index.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/index.md
@@ -16,34 +16,36 @@ UIViewController on iOS) that you can integrate in your mobile application in
 the usual fashion. To work, these components need data from the Swedbank Pay
 APIs, which you must retrieve through your own servers. At the core, the
 libraries are agnostic as to how the communication between your app and your
-servers happens, but an implementation is provided for a server that implements
-what we call the Merchant Backend API. The Merchant Backend API is designed to
-transparently reflect the Swedbank Pay API, and the data types used to configure
-the mobile libraries allow you to organically discover the capabilities of the
-system.
+servers happens, but an example implementation is provided for a server that
+implements what we call the Merchant Backend API. The Merchant Backend API is
+designed to transparently reflect the Swedbank Pay API, and the data types used
+to configure the mobile libraries allow you to organically discover the
+capabilities of the system.
 
-The SDK is designed to integrate the Swedbank Pay UI inside your application's
-native UI. It generates any html pages required to show the Swedbank Pay UI
-internally; it does not support using a Checkout or Payments web page that you
-host yourself. If doing the latter fits your case better, you can show your web
-page in a Web View instead. In that case, you may benefit from the [collection
-of information about showing Checkout or Payments in a Web View][plain-webview].
+The SDK is designed to integrate the Swedbank Pay Seamless View Payment UI
+inside your application's native UI. It generates any html pages required to
+show the Swedbank Pay UI internally; it does not support using a Checkout or
+Payments web page that you host yourself. If doing the latter fits your case
+better, you can show your web page in a Web View instead. In that case, you may
+benefit from the [collection of information about showing Checkout or Payments
+in a Web View][plain-webview].
 
 ## Prerequisites
 
 To start integrating the Swedbank Pay Mobile SDK, you need the following:
 
-*   An [HTTPS][https] enabled web server.
 *   An agreement that includes [Swedbank Pay Digital Payments][checkout],
     specifically [Enterprise][checkout-enterprise] or [Payments
     Only][checkout-payments-only].
 *   Obtained credentials (merchant Access Token) from Swedbank Pay through
     the Merchant Portal. Please observe that the Swedbank Pay Digital Payments
     implementations currently available encompasses the **`paymentmenu`** scope.
+*   Optionally, a [HTTPS][https] enabled web server.
 
 It is important to secure all communication between your app and your servers.
-If you wish to use the Merchant Backend API to communicate between your app and
-your server, an example implementation is provided for Node.js and for Java.
+If you wish to use the example Merchant Backend API to communicate between your
+app and your server, an example implementation is provided for Node.js and for
+Java.
 
 ## Introduction
 

--- a/checkout-v3/modules-sdks/mobile-sdk/ios.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/ios.md
@@ -38,11 +38,11 @@ for the Merchant Backend utilities.
 Add the relevant dependencies in your `Podfile`:
 
 ```ruby
-pod 'SwedbankPaySDK', '~> 3.0'
+pod 'SwedbankPaySDK', '~> {{ page.mobile_sdk_ios_version }}'
 ```
 
 ```ruby
-pod 'SwedbankPaySDKMerchantBackend', '~> 3.0'
+pod 'SwedbankPaySDKMerchantBackend', '~> {{ page.mobile_sdk_ios_version }}'
 ```
 
 ## Url Scheme and Associated Domain

--- a/checkout-v3/modules-sdks/mobile-sdk/ios.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/ios.md
@@ -622,8 +622,8 @@ sequenceDiagram
 
 {% include iterator.html prev_href="/checkout-v3/modules-sdks/mobile-sdk/android"
                          prev_title="Back: Android"
-                         next_href="/checkout-v3/modules-sdks/mobile-sdk/custom-backend"
-                         next_title="Next: Custom Backend" %}
+                         next_href="/checkout-v3/modules-sdks/mobile-sdk/merchant-backend"
+                         next_title="Next: Merchant Backend" %}
 
 [xcode-swiftpm]: https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app
 [sdk-package-repo]: https://github.com/SwedbankPay/swedbank-pay-sdk-ios.git

--- a/checkout-v3/modules-sdks/mobile-sdk/ios.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/ios.md
@@ -635,13 +635,13 @@ sequenceDiagram
 [assoc-domains-entitlement]: /assets/img/mobile-sdk/ios-assoc-domain.png
 [ios-custom-scheme]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content/defining_a_custom_url_scheme_for_your_app
 [ios-universal-links]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content
-[ios-universal-links-routing]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content#3001753
+[ios-universal-links-routing]: https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content#Support-universal-links
 [ios-paymenturl-helper]: /checkout-v3/modules-sdks/mobile-sdk/merchant-backend#ios-payment-url-helper
 [uiappdelegate-continueuseractivity]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623072-application
 [uiappdelegate-openurl]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application
 [backend-aasa]: /checkout-v3/modules-sdks/mobile-sdk/merchant-backend#apple-app-site-association
 [xcode-add-cap]: https://help.apple.com/xcode/mac/current/#/dev88ff319e7
-[xcode-add-assoc-domain]: https://developer.apple.com/documentation/safariservices/supporting_associated_domains_in_your_app#3001207
+[xcode-add-assoc-domain]: https://developer.apple.com/documentation/xcode/supporting-associated-domains#Add-the-associated-domain-file-to-your-website
 [rfc-7807]: https://tools.ietf.org/html/rfc7807
 [swedbankpay-problems]: /checkout-v3/features/technical-reference/problems
 [backend-problems]: /checkout-v3/modules-sdks/mobile-sdk/merchant-backend#problems

--- a/checkout-v3/modules-sdks/mobile-sdk/merchant-backend-sample-code.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/merchant-backend-sample-code.md
@@ -4,7 +4,7 @@ permalink: /:path/merchant-backend-sample-code/
 description: |
   You can use Swedbank Pay provided sample code to jump-start your
   **Swedbank Pay Mobile SDK** application.
-menu_order: 900
+menu_order: 1300
 ---
 
 You can find sample implementations of the Merchant Backend at [this Github
@@ -24,9 +24,10 @@ are, of course, devoid of any business logic. They should, nevertheless, provide
 a good starting point toward integration with your business systems.
 
 {% include iterator.html prev_href="/checkout-v3/modules-sdks/mobile-sdk/merchant-backend"
-                         prev_title="Merchant Backend"
-                         next_href="/checkout-v3/modules-sdks/mobile-sdk/android"
-                         next_title="Android" %}
+                         prev_title="Back: Merchant Backend"
+                         next_href="/checkout-v3/modules-sdks/mobile-sdk/other-features"
+                         next_title="Next: Other Features" %}
+
 
 [backend-samples]: https://github.com/SwedbankPay/swedbank-pay-sdk-mobile-example-merchant
 [node-sample]: https://github.com/SwedbankPay/swedbank-pay-sdk-mobile-example-merchant/tree/main/examples/node.js/README.md

--- a/checkout-v3/modules-sdks/mobile-sdk/merchant-backend-v2.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/merchant-backend-v2.md
@@ -799,11 +799,6 @@ All these Merchant Backend problem types will have a URL in the format
 
 Your implementation is encouraged to define its own problem types for any domain-specific errors; you should namespace those problem types under a domain name under your control – usually the host name of the Merchant Backend.
 
-{% include iterator.html prev_href="./"
-                         prev_title="Introduction"
-                         next_href="/checkout-v3/modules-sdks/mobile-sdk/merchant-backend-sample-code"
-                         next_title="Merchant Backend Sample Code" %}
-
 [swagger]: https://github.com/SwedbankPay/swedbank-pay-sdk-mobile-example-merchant/blob/main/documentation/swedbankpaysdk_openapi.yaml
 [swagger-editor]: https://editor.swagger.io/?url=https://raw.githubusercontent.com/SwedbankPay/swedbank-pay-sdk-mobile-example-merchant/main/documentation/swedbankpaysdk_openapi.yaml
 [payment-url]: /old-implementations/payment-menu-v2/features/technical-reference/payment-url

--- a/checkout-v3/modules-sdks/mobile-sdk/merchant-backend-v2.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/merchant-backend-v2.md
@@ -809,7 +809,7 @@ Your implementation is encouraged to define its own problem types for any domain
 [payment-url]: /old-implementations/payment-menu-v2/features/technical-reference/payment-url
 [initiate-consumer-session]: /old-implementations/checkout-v2/checkin#step-1-initiate-session-for-consumer-identification
 [create-payment-order]: /old-implementations/checkout-v2/payment-menu#step-3-create-payment-order
-[android-intent-scheme]: https://developer.chrome.com/multidevice/android/intents
+[android-intent-scheme]: https://developer.chrome.com/docs/android/intents
 [ios-custom-scheme]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content/defining_a_custom_url_scheme_for_your_app
 [ios-universal-links]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content
 [ios-universal-links-routing]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content#3001753

--- a/checkout-v3/modules-sdks/mobile-sdk/merchant-backend.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/merchant-backend.md
@@ -3,8 +3,8 @@ title: Merchant Backend V3
 permalink: /:path/merchant-backend/
 description: |
   To use the **Swedbank Pay Mobile SDK**, you must have a backend server
-  that communicates with your Configuration. The fastest way to start
-  developing is to use the Merchant Backend API.
+  that communicates with your Configuration. One way to start developing
+  is to use the Merchant Backend API.
 menu_order: 1200
 ---
 

--- a/checkout-v3/modules-sdks/mobile-sdk/merchant-backend.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/merchant-backend.md
@@ -5,7 +5,7 @@ description: |
   To use the **Swedbank Pay Mobile SDK**, you must have a backend server
   that communicates with your Configuration. The fastest way to start
   developing is to use the Merchant Backend API.
-menu_order: 800
+menu_order: 1200
 ---
 
 The Merchant Backend API serves as a simple starting point, and an illustrative
@@ -686,10 +686,10 @@ Your implementation is encouraged to define its own problem types for any
 domain-specific errors; you should namespace those problem types under a domain
 name under your control – usually the host name of the Merchant Backend.
 
-{% include iterator.html prev_href="./"
-                         prev_title="Introduction"
+{% include iterator.html prev_href="/checkout-v3/modules-sdks/mobile-sdk/ios"
+                         prev_title="Back: iOS"
                          next_href="/checkout-v3/modules-sdks/mobile-sdk/merchant-backend-sample-code"
-                         next_title="Merchant Backend Sample Code" %}
+                         next_title="Next: Merchant Backend Sample Code" %}
 
 [swagger]: https://github.com/SwedbankPay/swedbank-pay-sdk-mobile-example-merchant/blob/main/documentation/swedbankpaysdk_openapi.yaml
 [swagger-editor]: https://editor.swagger.io/?url=https://raw.githubusercontent.com/SwedbankPay/swedbank-pay-sdk-mobile-example-merchant/main/documentation/swedbankpaysdk_openapi.yaml

--- a/checkout-v3/modules-sdks/mobile-sdk/merchant-backend.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/merchant-backend.md
@@ -695,11 +695,11 @@ name under your control – usually the host name of the Merchant Backend.
 [swagger-editor]: https://editor.swagger.io/?url=https://raw.githubusercontent.com/SwedbankPay/swedbank-pay-sdk-mobile-example-merchant/main/documentation/swedbankpaysdk_openapi.yaml
 [payment-url]: /old-implementations/payment-menu-v2/features/technical-reference/payment-url
 [create-payment-order]: /checkout-v3/get-started/payment-request
-[android-intent-scheme]: https://developer.chrome.com/multidevice/android/intents
+[android-intent-scheme]: https://developer.chrome.com/docs/android/intents
 [ios-custom-scheme]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content/defining_a_custom_url_scheme_for_your_app
 [ios-universal-links]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content
-[ios-universal-links-routing]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content#3001753
-[ios-aasa]: https://developer.apple.com/documentation/safariservices/supporting_associated_domains_in_your_app#3001215
+[ios-universal-links-routing]: https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content#Support-universal-links
+[ios-aasa]: https://developer.apple.com/documentation/xcode/supporting-associated-domains#Add-the-associated-domain-file-to-your-website
 [rfc-7807]: https://tools.ietf.org/html/rfc7807
 [swedbankpay-problems]: /checkout-v3/features/technical-reference/problems
 [instrument-mode]: /old-implementations/payment-menu-v2/features/optional/instrument-mode

--- a/checkout-v3/modules-sdks/mobile-sdk/plain-webview.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/plain-webview.md
@@ -1,5 +1,5 @@
 ---
-title: Plain Webview
+title: Plain Web View
 permalink: /:path/plain-webview/
 description: |
   The **Swedbank Pay Mobile SDK** aims to provide an easy way of integrating
@@ -51,10 +51,10 @@ your existing web page using Checkout or Payments, and expect to embed it inside
 your mobile application using a web view.
 
 Indeed, on a high level this is what the SDK mobile client components do, in
-addition to providing native Swift and Kotlin APIs to the servie. The SDK
+addition to providing native Swift and Kotlin APIs to the service. The SDK
 internally generates a web page that shows the Checkout payment menu, so the
 developer need not concern themselves with html or other web-specific
-technologies. An exisiting web implementation would not really benefit from the
+technologies. An existing web implementation would not really benefit from the
 extra discoverability and quality-of-life improvements of a mobile-native API,
 so the SDK's value proposition seems to be little benefit for substantial
 reimplementation work.
@@ -355,7 +355,7 @@ eventually execute code like
 
 ## External Applications
 
-Before starting to implement lauching external applications, you should try to
+Before starting to implement launching external applications, you should try to
 get at least one card payment working. With completion observing in place, you
 should be able to complete a payment flow, at least using the External
 Integration environment and its test cards.
@@ -377,7 +377,7 @@ this is a deliberate privacy measure. What can be done, and what also happens to
 be exactly what we want to do, is to attempt to open a url and receive a
 callback telling us whether it succeeded. Nowadays, the recommended way of
 opening external applications is to use Universal Links, anyway, which are, on
-the surface, indistiguishable from web links.
+the surface, indistinguishable from web links.
 
 {:.code-view-header}
 **iOS**
@@ -656,12 +656,13 @@ be opened in your app. This is what the SDK does.
 The SDK does this by having `paymentUrl` return an html page that immediately
 redirects. In some cases the redirect will be blocked, so the page also contains
 a link to the same url, so the user can manually follow the redirect. Now, as
-here we seem to want to have `paymentUrl` be the url loaded in the WebView, this
-does not work out-of-the-box. One option is to override `shouldInterceptRequest`
-in your `WebViewClient`, and special-case the loading of `paymentUrl`. Another
-solution could be loading `paymentUrl` normally, but adding a script to the page
-that checks for a JavaScript interface you provide in the WebView, and it is not
-there, then it would issue the redirect to the intent url.
+here we seem to want to have `paymentUrl` be the url loaded in the Web View,
+this does not work out-of-the-box. One option is to override
+`shouldInterceptRequest` in your `WebViewClient`, and special-case the loading
+of `paymentUrl`. Another solution could be loading `paymentUrl` normally, but
+adding a script to the page that checks for a JavaScript interface you provide
+in the WebView, and it is not there, then it would issue the redirect to the
+intent url.
 
 For reference, the way the SDK handles `paymentUrl`s on Android looks like this
 from the perspective of the backend:

--- a/checkout-v3/modules-sdks/mobile-sdk/plain-webview.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/plain-webview.md
@@ -9,7 +9,7 @@ description: |
   Experience from developing the SDK may still be valuable for integrators
   wishing to show Payments pages in a Web View inside a mobile application.
   This page serves as a repository of that experience.
-menu_order: 1500
+menu_order: 1600
 ---
 
 {% capture disclaimer %}
@@ -735,7 +735,7 @@ The iOS (and possibly Android) SDKs will contain a list of known-good 3DS pages.
 Feel free to use this as a resource in your own implementation.
 
 {% include iterator.html prev_href="/checkout-v3/modules-sdks/mobile-sdk/process-diagrams"
-                         prev_title="Process Diagrams" %}
+                         prev_title="Back: Process Diagrams" %}
 
 [ios-universal-links]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content
 [sdk-paymenturl]: /checkout-v3/modules-sdks/mobile-sdk/ios#payment-url-and-external-applications

--- a/checkout-v3/modules-sdks/mobile-sdk/plain-webview.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/plain-webview.md
@@ -739,7 +739,7 @@ Feel free to use this as a resource in your own implementation.
 
 [ios-universal-links]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content
 [sdk-paymenturl]: /checkout-v3/modules-sdks/mobile-sdk/ios#payment-url-and-external-applications
-[android-autoverify]: https://developer.android.com/training/app-links/verify-site-associations
-[android-intent-scheme]: https://developer.chrome.com/multidevice/android/intents
+[android-autoverify]: https://developer.android.com/training/app-links/verify-android-applinks
+[android-intent-scheme]: https://developer.chrome.com/docs/android/intents
 [android-package-visibility]: https://developer.android.com/training/package-visibility
 [android-flag-non-browser]: https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_REQUIRE_NON_BROWSER

--- a/checkout-v3/modules-sdks/mobile-sdk/process-diagrams.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/process-diagrams.md
@@ -461,5 +461,5 @@ sequenceDiagram
                          next_href="/checkout-v3/modules-sdks/mobile-sdk/plain-webview"
                          next_title="Using a Web View Instead" %}
 
-[android-intent-scheme]: https://developer.chrome.com/multidevice/android/intents
+[android-intent-scheme]: https://developer.chrome.com/docs/android/intents
 [ios-universal-links]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content

--- a/checkout-v3/modules-sdks/mobile-sdk/process-diagrams.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/process-diagrams.md
@@ -8,7 +8,7 @@ description: |
   It is recommended to read through the earlier pages first.
   This page can them help you keep a picture of the whole system in mind,
   and serve as a quick reference to the different steps and components.
-menu_order: 1400
+menu_order: 1500
 ---
 
 ## Initialization
@@ -459,7 +459,7 @@ sequenceDiagram
 {% include iterator.html prev_href="/checkout-v3/modules-sdks/mobile-sdk/other-features"
                          prev_title="Back: Other Features"
                          next_href="/checkout-v3/modules-sdks/mobile-sdk/plain-webview"
-                         next_title="Using a Web View Instead" %}
+                         next_title="Next: Plain Web View" %}
 
 [android-intent-scheme]: https://developer.chrome.com/docs/android/intents
 [ios-universal-links]: https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content

--- a/checkout-v3/payment-presentations.md
+++ b/checkout-v3/payment-presentations.md
@@ -17,9 +17,10 @@ rates and new user adoption that comes with it.
 
 ### Domain Verification
 
-To ensure that we can enable ApplePay for you, there are a few steps you need to
-take. If you're using a Redirect integration, you are all set and can skip this
-step. If you're using a Seamless View integration, you need to do the following:
+To ensure that we can enable Apple Pay for you, there are a few steps you need
+to take. If you're using a Redirect integration, you are all set and can skip
+this step. If you're using a Seamless View integration, you need to do the
+following:
 
 1.  Download the [domain file][payex-domain-file] (right click and "Save as").
     -   Make sure you do not change, edit or manipulate the file in any way,
@@ -28,12 +29,12 @@ step. If you're using a Seamless View integration, you need to do the following:
     ".txt", ".doc", ".mp4" or any other extension to the file.
 
 2.  Upload the file to the following web path:
-    _https://[DOMAIN-NAME]/.well-known/apple-developer-merchantid-domain-association_
-    -   Replace [DOMAIN-NAME] with your own domain.
+    `https://[DOMAIN-NAME]/.well-known/apple-developer-merchantid-domain-association`
+    -   Replace `[DOMAIN-NAME]` with your own domain.
     -   If your website is https://example.com, then the site would be
-    _https://example.com/.well-known/apple-developer-merchantid-domain-association_
-    -   If you want to activate ApplePay on multiple domains, for example
-    _https://ecom.payex.com_ and _https://developer.swedbankpay.com_), you need
+    `https://example.com/.well-known/apple-developer-merchantid-domain-association`
+    -   If you want to activate Apple Pay on multiple domains, for example
+    `https://ecom.payex.com` and `https://developer.swedbankpay.com`, you need
     to upload the file to all of the unique domains.
 
 3.  Verify that the file has been uploaded correctly by opening the site. You
@@ -42,9 +43,16 @@ step. If you're using a Seamless View integration, you need to do the following:
     [this site][swp-file-site].
     -   If done correctly, they should look identical.
 
-If you're using our **iOS SDK**, make sure that the **WebViewBaseURL** is set to
-the same domain as where you host the file. If not, it may fail to validate,
-making it so payments with Apple Pay may not function.
+If you're using our **iOS SDK**, make sure that the `webViewBaseURL` is set to
+the same domain as where you host the file. If you're presenting Seamless View
+payments in a custom **plain web view** implementation in your iOS application,
+you need to make sure that the provided `baseURL` in the call to
+`loadHTMLString(_:baseURL:)` is set to the same domain as where you host the
+file. If not, it may fail to validate, making it so payments with Apple Pay
+may not function. You also need to make sure that Apple Pay scripts are allowed
+to be loaded and executed in the web view (relevant if you're implementing
+`WKNavigationDelegate` and your own
+`webView(_:decidePolicyFor:decisionHandler:)` implementation).
 
 Once the previous steps have been completed, get in touch with us to activate
 Apple Pay. The verification file is a hex string that contains a **JSON**. If


### PR DESCRIPTION
In this PR, we've made several improvements to the Mobile SDK documentation chapters.

* Restructure of the documentation to prioritise the more common Custom Backend approach to implement the mobile SDK, and with that moved the Merchant Backend API instructions down in order.
* Added a new chapter for a Bare Minimum Implementation of the SDKs on both iOS and Android to get a better grasp of the SDKs and enable the merchant to present the payment UI in their app with as few steps as possible.
* Additions and smaller fixes for the Apple Pay integration guide, mainly covering the option for merchants to use a plain web view without the mobile SDKs and still use Apple Pay as an instrument.
* Fixing spelling errors, broken links, outdated code examples, etc.
* Added Mobile SDK versions as config variables so that we can keep the documentation up to date easier with SDK bumps in the future.