### PR TITLE
ESY-6291 Updated look of Release notes to match Design guide examples

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :jekyll_plugins do
   gem 'kramdown', '>= 2.3'
   gem 'kramdown-plantuml', '>= 1.3'
   gem 'rouge', '>= 4.0.1'
-  gem 'swedbank-pay-design-guide-jekyll-theme', '2.2.8'
+  gem 'swedbank-pay-design-guide-jekyll-theme', '2.3.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    swedbank-pay-design-guide-jekyll-theme (2.2.8)
+    swedbank-pay-design-guide-jekyll-theme (2.3.0)
       awesome_print
       faraday (>= 1.0.1, < 3)
       jekyll (>= 3.7, < 5.0)
@@ -205,7 +205,7 @@ DEPENDENCIES
   rspec (>= 3)
   rubocop (>= 1)
   rubocop-rake (>= 0.6)
-  swedbank-pay-design-guide-jekyll-theme (= 2.2.8)
+  swedbank-pay-design-guide-jekyll-theme (= 2.3.0)
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/checkout-v3/release-notes.md
+++ b/checkout-v3/release-notes.md
@@ -5,11 +5,8 @@ description: |
   The latest updates about our Digital Payments releases will be
   published on this page.
 menu_order: 7
+release_notes: true
 ---
-
-{% include alert.html type="informative" icon="info" header="Version numbers"
-body="The version numbers used in headers on this page refers to the version of
-this very documentation, not to a version of any APIs described by it." %}
 
 ## 21 March 2024
 
@@ -52,7 +49,7 @@ that a token has been created.
 
 Big changes are coming up next time. Stay tuned!
 
-## 06 Jan 24
+## 6 February 2024
 
 ### Version 4.7.0
 
@@ -83,7 +80,7 @@ In addition to the usual handful of improvements and bug fixes, of course.
 
 Until next time!
 
-## 19 Dec 23
+## 19 December 2023
 
 ### Version 4.6.1
 
@@ -97,7 +94,7 @@ if you want to learn more about what it is.
 
 From all of us, to all of you: Merry Christmas!
 
-## 07 Nov 23
+## 7 November 2023
 
 ### Version 4.6.0
 
@@ -148,7 +145,7 @@ an easier time finding the right result in the correct section.
 
 Big things are coming up around the bend. Stay tuned!
 
-## 06 July 2023
+## 6 July 2023
 
 ### Version 4.3.3
 
@@ -232,7 +229,7 @@ implementation is still here, and for those of you with a Strong Consumer
 Authentication who want access to our safely stored card data,
 [Enterprise][checkout-v3-enterprise] is still available too.
 
-## 03 March 2023
+## 3 March 2023
 
 ### Version 4.0.0
 
@@ -314,7 +311,7 @@ instruments in both [status][status-models] and
 added MobilePay to [Request Delivery Information][request-delivery-information]
 and done away with some more bugs and typos.
 
-## 02 September 2022
+## 2 September 2022
 
 ### Version 3.1.2
 
@@ -328,7 +325,7 @@ navigation easier, added a section on
 [deleting payment tokens][delete-payment-tokens], along with the usual batch of
 assorted bug fixes and typos.
 
-## 01 July 2022
+## 1 July 2022
 
 ### Version 3.1.1
 
@@ -353,7 +350,7 @@ and integrations. There are a couple of other new additions as well:
   been added to instrument mode
 *   Fixed typos, minor bugs and code examples
 
-## 04 April 2022
+## 4 April 2022
 
 ### Version 3.0.3
 
@@ -423,7 +420,7 @@ new?
 *   Added important info about [MobilePay shoplogoUrl][mobilepay-seamless-view]
 *   Fixed minor bugs and code examples
 
-## 03 August 2021
+## 3 August 2021
 
 ### Version 2.2.2
 
@@ -442,7 +439,7 @@ new?
 *   Added [Delete Token section][card-delete-token] in Card's technical reference
 *   Fixed minor typos and bugs
 
-## 30 Apr 2021
+## 30 April 2021
 
 ### Version 2.2.0
 
@@ -451,14 +448,14 @@ new?
 *   Added [TRA exemption][tra-exemption] section
 *   Fixed a handful of typos and bugs
 
-## 28 Jan 2021
+## 28 January 2021
 
 ### Version 2.1.2
 
 *   Updated Theme version to 1.9.9
 *   Updated Design Guide Version to 5.0.1
 
-## 26 Jan 2021
+## 26 January 2021
 
 ### Version 2.1.0
 
@@ -473,7 +470,7 @@ new?
 *   Updated GitHub references for Mobile SDK
 *   Re-wrote [Prices][prices] section
 
-## 01 Dec 2020
+## 1 December 2020
 
 ### Version 2.0.2
 
@@ -483,7 +480,7 @@ new?
 *   Added paragraphs about different consumer flows in [Checkin][Checkin]
 *   Added link to gift card on the [front page][frontpage]
 
-## 12 Nov 2020
+## 12 November 2020
 
 ### Version 2.0.1
 
@@ -491,7 +488,7 @@ new?
 *   Split [MobilePay Capture][mobilepay-capture] to a separate page
 *   Code examples for digital products added in [Checkin][Checkin]
 
-## 11 Nov 2020
+## 11 November 2020
 
 ### Version 2.0.0
 
@@ -518,7 +515,7 @@ Other changes:
 *   Updated [callback][checkout-callback] documentation.
 *   Updated regex pattern for `orderItems.class`.
 
-## 04 Sep 2020
+## 4 September 2020
 
 ### Version 1.13.3
 
@@ -530,7 +527,7 @@ Other changes:
 *   Documented problems in [Trustly Payments][trustly-payments].
 *   Added an alert for two-phase payments in Capture pages.
 
-## 28 Aug 2020
+## 28 August 2020
 
 ### Version 1.13.2
 
@@ -544,7 +541,7 @@ Other changes:
 *   Added a list of accepted banks in [Trustly Payments][trustly-payments].
 *   Updated the `UpdateOrder` description in [Checkout][checkout].
 
-## 21 Aug 2020
+## 21 August 2020
 
 ### Version 1.13.1
 
@@ -554,7 +551,7 @@ Other changes:
 *   Updated [Test Data][test-data] for Vipps Payments.
 *   Added updated documentation on the `transaction` operation.
 
-## 17 Jul 2020
+## 17 July 2020
 
 ### Version 1.13.0
 
@@ -562,14 +559,14 @@ Other changes:
 *   Added tables for mapping API fields to settlement files in
     [Settlement and Reconciliation][settlement-reconcilitation].
 
-## 10 Jul 2020
+## 10 July 2020
 
 ### Version 1.12.1
 
 *   Corrected the documentation by removing `generatePaymentToken` and
     `paymentToken` from [Checkout][checkout].
 
-## 07 Jul 2020
+## 07 July 2020
 
 ### Version 1.12.0
 
@@ -589,7 +586,7 @@ Other changes:
 *   Small corrections to [Swish Payments][swish] documentation.
 *   Clarified the [`updateOrder`][update-order-checkout] documentation.
 
-## 04 Jun 2020
+## 4 June 2020
 
 ### Version 1.11.1
 
@@ -622,7 +619,7 @@ Other changes:
 *   Added a new section [Co-badge Card Choice for Dankort][co-badge-card] in
     [Card Payments][card-payment-url].
 
-## 07 May 2020
+## 7 May 2020
 
 ### Version 1.9.2
 
@@ -637,7 +634,7 @@ Other changes:
 *   The `language` field is now better described for all requests it's present in.
 *   All broken links should now be unbroken.
 
-## 22 Apr 2020
+## 22 April 2020
 
 ### Version 1.9.0
 
@@ -648,7 +645,7 @@ Other changes:
 *   Flags now also sport a new look: {% flag no %} {% flag se %} {% flag dk %}
     {% flag fi %} {% flag lt %} {% flag lv %} {% flag ee %}
 
-## 15 Apr 2020
+## 15 April 2020
 
 ### Version 1.8.3
 
@@ -668,7 +665,7 @@ Other changes:
 *   Updated the [main page][frontpage] to be more welcoming.
 *   Updated information on [Delegated Strong Customer Authentication][mac-checkout].
 
-## 31 Mar 2020
+## 31 March 2020
 
 ### Version 1.8.1
 
@@ -683,7 +680,7 @@ Other changes:
 *   Updated `payeeReference` to have an unique description for Payment Order and
     every Payment Instrument.
 
-## 18 Mar 2020
+## 18 March 2020
 
 ### Version 1.8.0
 
@@ -696,14 +693,14 @@ Other changes:
 
 This change contains build updates for the page. :octocat:
 
-## 04 Mar 2020
+## 04 March 2020
 
 ### Version 1.7.6
 
 *   Several links has been corrected. The chance of 404 is now much lower.
 *   Other small text changes and clarifications.
 
-## 03 Mar 2020
+## 03 March 2020
 
 ### Version 1.7.5
 
@@ -719,7 +716,7 @@ This change contains build updates for the page. :octocat:
 *   Described the M-Commerce flow for [Swish Direct][swish-direct-mcom].
 *   Alphabetize the terms in [Terminology][terminology].
 
-## 27 Feb 2020
+## 27 February 2020
 
 ### Version 1.7.3
 
@@ -731,7 +728,7 @@ This change contains build updates for the page. :octocat:
 *   Mobile Pay Online was previously only referred to as Mobile Pay, this has been
     corrected.
 
-## 7 Feb 2020
+## 7 February 2020
 
 ### Version 1.7.2
 
@@ -741,7 +738,7 @@ This change contains build updates for the page. :octocat:
 *   We have added card logos when selecting card in payment menu.
     See [updated screenshot of payment menu][checkout-payment-menu-frontend].
 
-## 6 Feb 2020
+## 6 February 2020
 
 ### Version 1.7.1
 
@@ -764,7 +761,7 @@ All sections have been released. :trophy:
     [Swish Seamless View][swish-seamless-view]. Properties added in `Swish`.
 *   Added section about migration key in Resources section.
 
-## 29 Jan 2020
+## 29 January 2020
 
 ### Version 1.6.3
 
@@ -785,7 +782,7 @@ All sections have been released. :trophy:
 *   `cardholder` added to [Card Payments Purchase requests][card-purchase].
 *   Various improvements and fixes.
 
-## 27 Jan 2020
+## 27 January 2020
 
 ### Version 1.6.0
 
@@ -798,7 +795,7 @@ All sections have been released. :trophy:
 *   Added descriptions for Payment States And Transaction States everywhere appropriate.
 *   Google Analytics has been added to Developer Portal.
 
-## 16 Jan 2020
+## 16 January 2020
 
 ### Version 1.5
 
@@ -809,7 +806,7 @@ All sections have been released. :trophy:
 *   The [Swish Payments][swish] and [Vipps Payments][vipps] sections are ready for
     review.
 
-## 09 Jan 2020
+## 9 January 2020
 
 ### Version 1.4
 
@@ -826,7 +823,7 @@ All sections have been released. :trophy:
 *   Added description for the `onBillingDetailsAvailable` event in the
     [Checkin Front End section][checkout-checkin-front-end].
 
-## 22 Dec 2019
+## 22 December 2019
 
 ### Update in checkin module
 
@@ -852,7 +849,7 @@ redirect>>doc:Main.ecommerce.payex-payment-instruments.swish-payments.swish-e-co
 model.
 {% endcomment %}
 
-## 01 Nov 2019
+## 1 November 2019
 
 ### Welcome, Swedbank Pay Developer Portal
 
@@ -904,7 +901,7 @@ updated documentation
 [[here>>doc:Main.ecommerce.technical-reference.payment-orders-resource.WebHome]]
 {% endcomment %}
 
-## 01 Oct 2019
+## 1 October 2019
 
 ### Payment Url Credit Card
 
@@ -923,7 +920,7 @@ invoked after return of the payer, they will either be redirected to
 the `completeUrl` (event onPaymentCompleted) or if payment has failed, see an
 error-message and get the option to retry the payment.
 
-## 01 Aug 2019
+## 1 August 2019
 
 ### Order Items in payment orders
 
@@ -1008,7 +1005,6 @@ integration and the payer.
 [co-badge-card]: /old-implementations/payment-instruments-v1/card/features/optional/cobadge-dankort#co-badge-card-choice-for-dankort
 [core-features]: /old-implementations/checkout-v2/features/core/
 [credit-card-abort]: /old-implementations/payment-instruments-v1/card/after-payment#abort
-[credit]: /old-implementations/payment-instruments-v1/card
 [custom-styling]: /checkout-v3/features/optional/custom-styling
 [integrated-commerce]: /checkout-v3/features/optional/integrated-commerce
 [data-protection]: /old-implementations/checkout-v2/data-protection

--- a/pax-terminal/NET/release-notes.md
+++ b/pax-terminal/NET/release-notes.md
@@ -8,15 +8,17 @@ menu_order: 1
 icon:
     content: feed
     outlined: true
-
+release_notes: true
 ---
-## March 6 2024
+## 21 March 2024
+
+### Version 5.0.0
 
 *   Updated command for avoiding privilege elevation.
 *   Use case for easier configuration of terminal and POS system.
 *   Update of [TransactionSetup][transactionsetup] and property [AcquirerData][acquirerdata].
 
-### .Net SDK 1.3.24066
+##### .Net SDK 1.3.24066
 
 *   New package ID. SwedbankPay.Pax.Sdk. Still the same namespaces and dll name.
 *   Fix for display messages from fuel app that lacks text id.
@@ -24,9 +26,9 @@ icon:
 *   Fixed bug for PrintRequest with DocumentQualifier other other than CashierReceipt or CustomerReceipt.
 *   Possibility for Net Framework 4.0. Now supports Netstandard2.0, net framework 4.5 and 4.0.
 
-## February 27 2024
+## 26 February 2024
 
-### .Net SDK 1.3.24047
+### Version 4.8.0
 
 *   PaymentRequestResult now populates ProductName and PAN even if PaymentInstrumentData is missing.
 *   Possibility to use OpenEx or OpenExAsync to set OperatorID and ShiftNumber that will be forwarded and seen in reports.
@@ -37,54 +39,51 @@ icon:
 *   Property type of TransactionSetup is always overridden and set to Refund if Refund or RefundAsync is called.
 *   Default currency fixed when using TransactionSetup
 
-## February 6 2024
+## 6 February 2024
+
+### Version 4.7.0
 
 *   Documentation updated to reflect SDK release.
 *   Text updated for [`TransactionSetup`][transactionsetup]
 *   Use case section, apm transaction, apm refund, cvm signtature and fuel card transaction and auto configuration of terminal IP in the POS.
 
-## January 25 2024
-
-### .Net SDK 1.3.24025
+##### .Net SDK 1.3.24025
 
 *   RequestToDisplay and UpdateTerminal have now corrected results.
 *   ReverseLast now automatically makes retries if the terminal responds busy.
 *   OnTerminalAddressObtainedEventCallback now with correct access modifier to be able to access Ipv4 and Port properties.
 
-## January 16 2024
-
-### .Net SDK 1.3.24016
+##### .Net SDK 1.3.24016
 
 *   CardAcquisitionReference is now a copy of POITransactionID. Earlier time was converted to local time and caused problem when an other timezone was used.
 *   [PaymentRequetsResult][paymentrequestresult] has now a lot of properties to make values easily available.
 
-## December 15 2023
+## 19 December 2023
 
-### .Net SDK version 1.3.23348
+### Version 4.6.1
+
+##### .Net SDK version 1.3.23348
 
 *   CVM signature transaction works just the same for Client Only mode as for default Client and Server mode.
 *   [`ConfirmationHandler`][confirmationhandler] callback is a must even for Client Only mode.
 *   [`EventCallback`][eventcallback] for `PrintRequestEventCallback` is a must even for Client Only mode.
 *   [Code Examples][codeexamples] updated.
 
-## December 11 2023
+##### .Net SDK Version 1.3
 
-### .Net SDK Version 1.3
+*   Extended interface with function [RequestToPrint][requesttoprint].
+*   Extended [TransactionSetup][transactionsetup] with a list of SaleItem to be used with fuel functionality.
+*   ReceiptBlob and ReceiptBlobNoHeader has been shortened and compressed.
 
-Extended interface with function [RequestToPrint][requesttoprint].
+## 7 November 2023
 
-Extended [TransactionSetup][transactionsetup] with a list of SaleItem to be used with fuel functionality.
+### Version 4.6.0
 
-ReceiptBlob and ReceiptBlobNoHeader has been shortened and compressed.
+##### .Net SDK Version 1.2
 
-## 03 November 2023
-
-### .Net SDK Version 1.2
-
-SDK for .Net has extended its interface with new methods for [GetPaymentInstrument][getpaymentinstrument],
+*   SDK for .Net has extended its interface with new methods for [GetPaymentInstrument][getpaymentinstrument],
 [Payment][payment] and [Refund][refund] for which an object with parameters is passed. This was made to be able set a transaction id from the sale system.
-
-ReceiptBlobNoHeader has been added to PaymentRequestResult.
+*   ReceiptBlobNoHeader has been added to PaymentRequestResult.
 
 [getpaymentinstrument]:/pax-terminal/NET/SwpTrmLib/Methods/handy/getpaymentinstrumentasync
 [payment]: /pax-terminal/NET/SwpTrmLib/Methods/essential/paymentasync

--- a/pax-terminal/release-notes.md
+++ b/pax-terminal/release-notes.md
@@ -5,13 +5,19 @@ description: |
   The latest updates about PAX-terminal integration and documentation will be
   published on this page.
 menu_order: 100
+release_notes: true
 ---
-## February 27 2024
+
+## 26 February 2024
+
+### Version 4.8.0
 
 *   Purchase order number may be included in payment and forwarded to Pospay.
 *   Updates for the [.Net SDK][dotnetrelease]
 
 ## 6 February 2024
+
+### Version 4.7.0
 
 *   [Manually entered Payment Instrument explained][keyinpaymentinstrument].
 *   [Automatic configuration of terminal address in POS][autoconfig].
@@ -19,22 +25,19 @@ menu_order: 100
 *   Structural changes of documentation for [.Net SDK][dotnetrelease].
 *   Updates for the [.Net SDK][dotnetrelease]
 
-## 15 December 2023
+## 19 December 23
 
-*   Updates for the [.Net SDK][dotnetrelease]
-
-## 11 December 2023
+### Version 4.6.1
 
 *   Possibility to send PrintRequest to A920Pro.
-
 *   Documentation about fuel functionality.
-
 *   Updates for the [.Net SDK][dotnetrelease].
 
-## 03 November 2023
+## 7 November 23
+
+### Version 4.6.0
 
 *   Updated documentation for the [.Net SDK][dotnetrelease] and new methods in the interface.
-
 *   Added documentation about direct integration and the nexo Retailer interface.
 
 [dotnetrelease]: /pax-terminal/NET/release-notes


### PR DESCRIPTION
[ESY-6291 Release notes style](https://payexjira.atlassian.net/browse/ESY-6291)

We have updated the look of the release notes to match the design in Design Guide. Suggestion is the following:
- Use the planned release date and not the commit date
- Write date as D MMMM YYYY (ex. 6 January 2024)
- Always a version number
- "sub headers" allowed but must be at least h4 `####`

We need to make sure we all use the same date format. Also the date & version should be the same across the different release notes  - if something is new that is. And with that I mean:

```
- Digital Payments have changes for version 1 on 1 January 2001, version 2 on 2 February 2001 and for version 3 on 3 March 2001
- PAX have changes for version 1 on 1 January 2001 and version 3 on 3 March 2001
- PAX .NET have changes for version 1 on 1 January 2001 and version 2 on 2 February 2001

The resulting notes will then be:

Digital Payments
- 3 March 2001 - version 3
- 2 February 2001 - version 2 
- 1 January 2001 - version 1

PAX
- 3 March 2001 - version 3
- 1 January 2001- version 1

PAX .NET
- 2 February 2001 - version 2
- 1 January 2001 - version 1
```

I have updated your release notes according to the specs above. Please take a look and see if yo agree :-) 