### PR TITLE
Feature/esy 6972 No card decoration for one time payments

### DIFF
--- a/checkout-v3/index.md
+++ b/checkout-v3/index.md
@@ -49,7 +49,7 @@ this section. We recommend [getting started here][get-started].
          <span class="cards-content">
             <span class="h4">One-Time Payments</span>
             <span>
-               <p>Get things started with our basic implementation.</p>
+               <p>Get things started with our basic implementation for all payment methods.</p>
             </span>
          </span>
          <i class="material-icons">arrow_forward</i>

--- a/checkout-v3/index.md
+++ b/checkout-v3/index.md
@@ -50,7 +50,6 @@ this section. We recommend [getting started here][get-started].
             <span class="h4">One-Time Payments</span>
             <span>
                <p>Get things started with our basic implementation.</p>
-               <span class="badge badge-gray-light">All payment methods</span>
             </span>
          </span>
          <i class="material-icons">arrow_forward</i>


### PR DESCRIPTION
The card One-Time Payments should not have a decorator, instead the text should state "for all payment methods".