### PR TITLE
SDK-25: Web View based instruments from Native session

### DIFF
--- a/checkout-v3/modules-sdks/mobile-sdk/bare-minimum-implementation.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/bare-minimum-implementation.md
@@ -179,10 +179,11 @@ PaymentSession.paymentSessionState.observe(viewLifecycleOwner) { paymentState ->
 ## Android Present Payment
 
 You are now ready to present the payment UI. You can ask the payment session
-class to create a `PaymentFragment` for web view based payments:
+class to create a `PaymentFragment` for web view based payments.  We request a
+menu mode web view, without any restriction of instruments.
 
 ```kotlin
-paymentSession.createPaymentFragment()
+paymentSession.createPaymentFragment(mode = SwedbankPayPaymentSessionSDKControllerMode.Menu(null))
 ```
 
 After getting back the `PaymentFragment` instance , you can present it in a way
@@ -227,7 +228,7 @@ class MainActivity : AppCompatActivity() {
                     Log.d("SwedbankPay", "Payment Session Fetched")
 
                     // Reqeust a web based payment fragment instance
-                    paymentSession.createPaymentFragment()
+                    paymentSession.createPaymentFragment(mode = SwedbankPayPaymentSessionSDKControllerMode.Menu(null))
                 }
 
                 is PaymentSessionState.ShowPaymentFragment -> {
@@ -416,10 +417,11 @@ func paymentSessionCanceled() {
 ```
 
 You are now ready to present the payment UI. You can ask the payment session
-class to create a `SwedbankPaySDKController` for web view based payments.
+class to create a `SwedbankPaySDKController` for web view based payments. We
+request a menu mode web view, without any restriction of instruments.
 
 ```swift
-paymentSession.createSwedbankPaySDKController()
+paymentSession.createSwedbankPaySDKController(mode: .menu(restrictedToInstruments: nil))
 ```
 
 The `SwedbankPaySDKController` instance is returned via the
@@ -455,7 +457,7 @@ class ViewController: UIViewController, SwedbankPaySDKPaymentSessionDelegate {
 
     func paymentSessionFetched(availableInstruments: [SwedbankPaySDK.AvailableInstrument]) {
         print("Available Instruments Fetched")
-        paymentSession.createSwedbankPaySDKController()
+        paymentSession.createSwedbankPaySDKController(mode: .menu(restrictedToInstruments: nil))
     }
 
     func sessionProblemOccurred(problem: SwedbankPaySDK.ProblemDetails) {

--- a/checkout-v3/modules-sdks/mobile-sdk/native-payments.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/native-payments.md
@@ -240,9 +240,9 @@ the MSISDN string before making the native Swish payment attempt.
 
 When requesting local start, the SDK will automatically launch the Swish app on
 the local device. If an error occurred when starting the app, your app will be
-informed by the problem by receiving the `SdkProblemOccurred` payment state,
-where the `problem` parameter will be
-`PaymentSessionProblem.ClientAppLaunchFailed`.
+informed by the problem by receiving the `SessionProblemOccurred` payment state,
+where the `problem` parameter will have the `type` value
+`"https://api.payex.com/psp/errordetail/paymentorders/clientapplaunchfailed"`.
 
 ## Saved Credit Cards
 
@@ -619,9 +619,9 @@ the MSISDN string before making the native Swish payment attempt.
 
 When requesting local start, the SDK will automatically launch the Swish app on
 the local device. If an error occurred when starting the app, the SDK will call
-the `sdkProblemOccurred(problem:)` delegate method, and provide the
-`SwedbankPaySDK.PaymentSessionProblem.clientAppLaunchFailed` problem as
-parameter.
+the `sessionProblemOccurred(problem:)` delegate method, and provide a problem
+with type `type` parameter set to
+`"https://api.payex.com/psp/errordetail/paymentorders/clientapplaunchfailed"`.
 
 ## Saved Credit Cards
 
@@ -832,11 +832,6 @@ handled in the following ways:
     callback function on Android that you can call to retry the underlying API
     call. You should inform the user of the error and give the option to either
     abort the payment session or retry the call.
-*   `ClientAppLaunchFailed` informs you that the SDK have attempted to launch an
-    external app (such as Swish) and that it failed to do so. You should inform
-    the user of the problem and give them the option to either make a new
-    attempt (with any available payment method) or to abort the whole payment
-    session.
 *   `InternalInconsistencyError` is the result of an logic inconsistency problem
     in the SDK. An example of this would be to call `abortPaymentSession()`
     before `startPaymentSession()`. If you receive this error during

--- a/checkout-v3/modules-sdks/mobile-sdk/native-payments.md
+++ b/checkout-v3/modules-sdks/mobile-sdk/native-payments.md
@@ -977,7 +977,7 @@ if let instrument = availableInstruments.first(where: { $0.paymentMethod == "Inv
 
 ```kotlin
 availableInstruments.firstOrNull { it.paymentMethod == "Invoice-PayExFinancingSe" }?.let { instrument ->
-    paymentSession?.createPaymentFragment(SwedbankPayPaymentSessionSDKControllerMode.InstrumentMode(instrument = instrument))
+    paymentSession.createPaymentFragment(SwedbankPayPaymentSessionSDKControllerMode.InstrumentMode(instrument = instrument))
 }
 ```
 


### PR DESCRIPTION
In this PR, we're adding documentation for presenting web based payments in the new session methods in the mobile SDK.