### PR TITLE
Hotfix: Devp-782 - Remove Payer Service Documentation (master)

### DIFF
--- a/checkout-v3/features/optional/delay-pay-button.md
+++ b/checkout-v3/features/optional/delay-pay-button.md
@@ -2,7 +2,7 @@
 title: Payment Button Delay
 permalink: /:path/delay-pay-button/
 description: Delay the payment button execution until callback is received.
-menu_order: 2300
+menu_order: 2400
 ---
 
 {% include delay-pay-button.md %}

--- a/checkout-v3/features/optional/delete-tokens.md
+++ b/checkout-v3/features/optional/delete-tokens.md
@@ -1,14 +1,10 @@
 ---
-title: Token Handling
-permalink: /:path/token-handling/
+title: Delete Tokens
+permalink: /:path/delete-tokens/
 redirect_from: /checkout-v3/features/optional/delete-token/
-description: All things token related.
-menu_order: 2800
+description: Everything you need to delete tokens.
+menu_order: 1700
 ---
-
-The Payer Service API is dedicated solely to token handling.
-
-{% include payer-tokens.md %}
 
 ## Delete Unscheduled, Recurrence Or Payment Tokens
 

--- a/checkout-v3/features/optional/integrated-commerce.md
+++ b/checkout-v3/features/optional/integrated-commerce.md
@@ -2,7 +2,7 @@
 title: Integrated Commerce
 permalink: /:path/integrated-commerce/
 description: A printable, scannable reference code for payment tracking.
-menu_order: 1700
+menu_order: 1800
 ---
 
 {% include integrated-commerce.md %}

--- a/checkout-v3/features/optional/moto.md
+++ b/checkout-v3/features/optional/moto.md
@@ -6,7 +6,7 @@ description: |
                   <span class="d-block mt-3">
                     <span class="badge badge-default">Card</span>
                   </span>
-menu_order: 1800
+menu_order: 1900
 ---
 
 {% include payment-order-moto.md %}

--- a/checkout-v3/features/optional/one-click-payments.md
+++ b/checkout-v3/features/optional/one-click-payments.md
@@ -7,7 +7,7 @@ description: |
                 <span class="badge badge-default">Card</span>
                 <span class="badge badge-default">Trustly</span>
               </span>
-menu_order: 1900
+menu_order: 2000
 ---
 
 {% include one-click-payments.md %}

--- a/checkout-v3/features/optional/order-items.md
+++ b/checkout-v3/features/optional/order-items.md
@@ -2,7 +2,7 @@
 title: Order Items
 permalink: /:path/order-items/
 description: Information about the order items.
-menu_order: 2000
+menu_order: 2100
 ---
 
 {% include order-items.md %}

--- a/checkout-v3/features/optional/payer-aware-payment-menu.md
+++ b/checkout-v3/features/optional/payer-aware-payment-menu.md
@@ -7,7 +7,7 @@ description: |
                   <span class="badge badge-default">Card</span>
                   <span class="badge badge-default">Trustly</span>
                 </span>
-menu_order: 2100
+menu_order: 2200
 ---
 
 {% include payer-aware-payment-menu.md %}

--- a/checkout-v3/features/optional/payer-restrictions.md
+++ b/checkout-v3/features/optional/payer-restrictions.md
@@ -6,7 +6,7 @@ description: |
                   <span class="d-block mt-3">
                     <span class="badge badge-default">Swish</span>
                   </span>
-menu_order: 2200
+menu_order: 2900
 ---
 
 {% include payment-order-ssn-restrictions.md %}

--- a/checkout-v3/features/optional/payment-link.md
+++ b/checkout-v3/features/optional/payment-link.md
@@ -3,7 +3,7 @@ title: Payment Link
 permalink: /:path/payment-link/
 description: |
   Sending the payment via mail or SMS.
-menu_order: 2400
+menu_order: 2500
 ---
 
 {% include payment-order-payment-link.md %}

--- a/checkout-v3/features/optional/payout.md
+++ b/checkout-v3/features/optional/payout.md
@@ -5,7 +5,7 @@ description: Paying out funds to the consumer's account.
                 <span class="d-block mt-3">
                     <span class="badge badge-default">Trustly</span>
                 </span>
-menu_order: 2500
+menu_order: 2600
 ---
 
 {% include payout.md %}

--- a/checkout-v3/features/optional/recur.md
+++ b/checkout-v3/features/optional/recur.md
@@ -6,7 +6,7 @@ description: |
               <span class="d-block mt-3">
                 <span class="badge badge-default">Card</span>
               </span>
-menu_order: 2600
+menu_order: 2700
 ---
 
 {% include payment-order-recur.md %}

--- a/checkout-v3/features/optional/request-delivery-info.md
+++ b/checkout-v3/features/optional/request-delivery-info.md
@@ -9,7 +9,7 @@ description: |
                 <span class="badge badge-default">Google Pay&trade;</span>
                 <span class="badge badge-default">MobilePay</span>
               </span>
-menu_order: 2700
+menu_order: 2800
 ---
 
 {% include request-delivery-info.md %}

--- a/checkout-v3/features/optional/unscheduled.md
+++ b/checkout-v3/features/optional/unscheduled.md
@@ -7,7 +7,7 @@ description: |
                   <span class="badge badge-default">Card</span>
                   <span class="badge badge-default">Trustly</span>
                 </span>
-menu_order: 2900
+menu_order: 3000
 ---
 
 {% include payment-order-unscheduled.md %}

--- a/checkout-v3/features/optional/verify.md
+++ b/checkout-v3/features/optional/verify.md
@@ -7,7 +7,7 @@ description: |
                   <span class="badge badge-default">Card</span>
                   <span class="badge badge-default">Trustly</span>
                 </span>
-menu_order: 3000
+menu_order: 3100
 ---
 
 {% include payment-order-verify.md %}

--- a/release-notes/digital-payments.md
+++ b/release-notes/digital-payments.md
@@ -65,11 +65,6 @@ orders were available in Danish, English, Finnish, Norwegian and Swedish. We
 have expanded the range of languages to include Estonian, French, German,
 Latvian, Lithuanian, Polish, Russian and Spanish.
 
-A handful of new GET and PATCH requests and responses have been documented as
-the Payer Service went live a short time ago. As this regards tokens, we have
-grouped them together with the existing Delete Tokens section, and renamed it
-[Token Handling][token-handling].
-
 QR codes are now available for [Apple Pay][apple-pay] transactions, which makes
 it possible to convert even when the payer is on an unsupported device.
 
@@ -1399,7 +1394,7 @@ more convenient for both the integration and the payer.
 [cv2]: /old-implementations/checkout-v2/ui-migration/
 [integrated-commerce]: /checkout-v3/features/optional/integrated-commerce
 [data-protection]: /old-implementations/checkout-v2/data-protection
-[delete-payment-tokens]: /checkout-v3/features/optional/token-handling
+[delete-payment-tokens]: /checkout-v3/features/optional/delete-tokens
 [demoshop]: https://ecom.externalintegration.payex.com/pspdemoshop
 [design-guide]: https://design.swedbankpay.com/
 [display-ui]: /checkout-v3/get-started/display-ui
@@ -1503,7 +1498,6 @@ more convenient for both the integration and the payer.
 [terminology]: /checkout-v3/get-started/terminology
 [test-data]: /checkout-v3/test-data
 [token04]: /checkout-v3/technical-reference/problems/#creditcard-payments-mit---do-not-try-again--excessive-reattempts
-[token-handling]: /checkout-v3/features/optional/token-handling/
 [token-problems]: /checkout-v3/technical-reference/problems/#token-problems
 [tos-url]: /checkout-v3/features/customize-ui/tos
 [trustly-pres]: /checkout-v3/trustly-presentation


### PR DESCRIPTION
Removing new Payer Service API documentation and reverting to old Delete Tokens section. Keep content for later use.